### PR TITLE
Get guild roles on initialization

### DIFF
--- a/internal/discord/command-handlers.go
+++ b/internal/discord/command-handlers.go
@@ -15,14 +15,6 @@ var (
 	adminPermission int64 = discordgo.PermissionAdministrator
 )
 
-// DiscordReady initializes the bot and blocks the bot from proceeding until
-// initialization finishes
-func (d *Discord) DiscordReady(s *discordgo.Session, event *discordgo.Ready) {
-	defer d.Ready.Done()
-	d.AddCommands(s, event)
-	d.MapExistingRoles(s, event)
-}
-
 // AddCommands registers the slash commands with Discord
 func (d *Discord) AddCommands(s *discordgo.Session, event *discordgo.Ready) {
 	fmt.Printf("Initializing Discord...\n")
@@ -60,27 +52,6 @@ func (d *Discord) AddCommands(s *discordgo.Session, event *discordgo.Ready) {
 		if err != nil {
 			fmt.Printf("Could not add some commands: %v \n", err)
 		}
-	}
-}
-
-// MapExistingRoles takes the existing roles from all guilds the bot is in
-// and populates the Roles map
-func (d *Discord) MapExistingRoles(s *discordgo.Session, event *discordgo.Ready) {
-	fmt.Printf("Mapping existing roles...\n")
-
-	d.Roles = make(map[string]map[string]*discordgo.Role)
-
-	fmt.Printf("Found the following roles:\n")
-	for _, discordGuild := range event.Guilds {
-		guildID := discordGuild.ID
-		existingRoles := discordGuild.Roles
-		d.Roles[guildID] = make(map[string]*discordgo.Role)
-		fmt.Printf("Guild %v:\n", guildID)
-		for _, role := range existingRoles {
-			d.Roles[guildID][role.Name] = role
-			fmt.Printf("%v, ", role.Name)
-		}
-		fmt.Printf("\n")
 	}
 }
 

--- a/internal/discord/command-handlers.go
+++ b/internal/discord/command-handlers.go
@@ -15,6 +15,13 @@ var (
 	adminPermission int64 = discordgo.PermissionAdministrator
 )
 
+// DiscordReady initializes the bot and blocks the bot from proceeding until
+// initialization finishes
+func (d *Discord) DiscordReady(s *discordgo.Session, event *discordgo.Ready) {
+	defer d.Ready.Done()
+	d.AddCommands(s, event)
+}
+
 // AddCommands registers the slash commands with Discord
 func (d *Discord) AddCommands(s *discordgo.Session, event *discordgo.Ready) {
 	fmt.Printf("Initializing Discord...\n")

--- a/internal/discord/command-handlers.go
+++ b/internal/discord/command-handlers.go
@@ -20,6 +20,7 @@ var (
 func (d *Discord) DiscordReady(s *discordgo.Session, event *discordgo.Ready) {
 	defer d.Ready.Done()
 	d.AddCommands(s, event)
+	d.MapExistingRoles(s, event)
 }
 
 // AddCommands registers the slash commands with Discord
@@ -59,6 +60,27 @@ func (d *Discord) AddCommands(s *discordgo.Session, event *discordgo.Ready) {
 		if err != nil {
 			fmt.Printf("Could not add some commands: %v \n", err)
 		}
+	}
+}
+
+// MapExistingRoles takes the existing roles from all guilds the bot is in
+// and populates the Roles map
+func (d *Discord) MapExistingRoles(s *discordgo.Session, event *discordgo.Ready) {
+	fmt.Printf("Mapping existing roles...\n")
+
+	d.Roles = make(map[string]map[string]*discordgo.Role)
+
+	fmt.Printf("Found the following roles:\n")
+	for _, discordGuild := range event.Guilds {
+		guildID := discordGuild.ID
+		existingRoles := discordGuild.Roles
+		d.Roles[guildID] = make(map[string]*discordgo.Role)
+		fmt.Printf("Guild %v:\n", guildID)
+		for _, role := range existingRoles {
+			d.Roles[guildID][role.Name] = role
+			fmt.Printf("%v, ", role.Name)
+		}
+		fmt.Printf("\n")
 	}
 }
 

--- a/internal/discord/discord.go
+++ b/internal/discord/discord.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -9,7 +10,11 @@ import (
 type Discord struct {
 	Token               string
 	Session             *discordgo.Session
+	Ready               sync.WaitGroup
 	ModLoggingChannelID string
+
+	// Roles[guild_id][role_name]
+	Roles map[string]map[string]*discordgo.Role
 }
 
 // Start sets up the token and intents of the bot before it logs in

--- a/internal/discord/discord.go
+++ b/internal/discord/discord.go
@@ -37,6 +37,35 @@ func (d *Discord) Start() error {
 	return nil
 }
 
+// DiscordReady initializes the bot and blocks the bot from proceeding until
+// initialization finishes
+func (d *Discord) DiscordReady(s *discordgo.Session, event *discordgo.Ready) {
+	defer d.Ready.Done()
+	d.AddCommands(s, event)
+	d.MapExistingRoles(s, event)
+}
+
+// MapExistingRoles takes the existing roles from all guilds the bot is in
+// and populates the Roles map
+func (d *Discord) MapExistingRoles(s *discordgo.Session, event *discordgo.Ready) {
+	fmt.Printf("Mapping existing roles...\n")
+
+	d.Roles = make(map[string]map[string]*discordgo.Role)
+
+	fmt.Printf("Found the following roles:\n")
+	for _, discordGuild := range event.Guilds {
+		guildID := discordGuild.ID
+		existingRoles := discordGuild.Roles
+		d.Roles[guildID] = make(map[string]*discordgo.Role)
+		fmt.Printf("Guild %v:\n", guildID)
+		for _, role := range existingRoles {
+			d.Roles[guildID][role.Name] = role
+			fmt.Printf("%v, ", role.Name)
+		}
+		fmt.Printf("\n")
+	}
+}
+
 // StartInteraction is a helper function that responds to the user who invoked
 // the slash command ephemerally with the string message
 func StartInteraction(s *discordgo.Session, i *discordgo.Interaction, message string) error {

--- a/internal/discord/discord.go
+++ b/internal/discord/discord.go
@@ -13,7 +13,7 @@ type Discord struct {
 	Ready               sync.WaitGroup
 	ModLoggingChannelID string
 
-	// Roles[guild_id][role_name]
+	// The structure of the following map is Roles[guild_id][role_name]
 	Roles map[string]map[string]*discordgo.Role
 }
 

--- a/main.go
+++ b/main.go
@@ -34,14 +34,15 @@ func main() {
 // start adds all the commands and connects the bot to Discord.
 // Listens for CTRL+C then terminates the connection.
 func start(d *discord.Discord) {
-	d.Session.AddHandler(d.AddCommands)
+	d.Ready.Add(1)
+	d.Session.AddHandler(d.DiscordReady)
 	err := d.Session.Open()
 	if err != nil {
 		panic(fmt.Errorf("Could not open Discord session: %f", err))
 	}
 
+	d.Ready.Wait()
 	d.Session.AddHandler(d.InteractionCreate)
-
 	fmt.Println("Moddingway is ready. Press CTRL+C to exit.")
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)


### PR DESCRIPTION
This PR creates a map of existing roles on bot initialization. It also adds a wait before bot is fully initialized.
Map is structured like so: `Roles[guild_id][role_name]` where the value is a `*discordgo.Role`.