### PR TITLE
Make testing the bot easier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,6 @@ services:
       dockerfile: ./docker/App.Dockerfile
     environment:
       DISCORD_TOKEN: ${DISCORD_TOKEN}
+      DEBUG: ${DEBUG:-false}
+      GUILD_ID: ${GUILD_ID}
+      MOD_LOGGING_CHANNEL_ID: ${MOD_LOGGING_CHANNEL_ID}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,27 @@ func main() {
 	discordToken = strings.TrimSpace(discordToken)
 
 	d := &discord.Discord{}
-	d.Init(discordToken)
+
+	debug, _ := os.LookupEnv("DEBUG")
+	debug = strings.ToLower(debug)
+
+	if debug == "true" {
+		guildID, ok := os.LookupEnv("GUILD_ID")
+		if !ok {
+			panic("You must supply a GUILD_ID to start!")
+		}
+
+		modLoggingChannelID, ok := os.LookupEnv("MOD_LOGGING_CHANNEL_ID")
+		if !ok {
+			panic("You must supply a MOD_LOGGING_CHANNEL_ID to start!")
+		}
+
+		d.Token = discordToken
+		d.GuildID = guildID
+		d.ModLoggingChannelID = modLoggingChannelID
+	} else {
+		d.Init(discordToken)
+	}
 
 	fmt.Printf("Starting Discord...\n")
 	err := d.Start()


### PR DESCRIPTION
Part of #50 
Dependent on #27 and #29
Adds a way to easily override the default guild ID and log channel ID set in `const.go` through environment variables to test the bot on a personal server without having to change it every time.
To use, set `DEBUG` to true in `.env` and the corresponding `GUILD_ID` and `MOD_LOGGING_CHANNEL_ID`
Leaving this as draft until #27 and #29 is merged to prevent messy commits (will be redone when they are merged)