### PR TITLE
Make getting environment variables cleaner

### DIFF
--- a/internal/util/env-getter.go
+++ b/internal/util/env-getter.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"os"
+)
+
+// EnvGetter is a helper that removes the need for error checking
+// every single an environment variable is looked up
+// instead just moves error checking to the end of the block of code
+
+type EnvGetter struct {
+	EnvName string
+	Ok      bool
+}
+
+func (eg *EnvGetter) GetEnv(envName string) string {
+	if !eg.Ok {
+		return ""
+	}
+	eg.EnvName = envName
+	var ret string
+	ret, eg.Ok = os.LookupEnv(envName)
+	return ret
+}

--- a/internal/util/env-getter.go
+++ b/internal/util/env-getter.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"strings"
 )
 
 // EnvGetter is a helper that removes the need for error checking
@@ -20,5 +21,6 @@ func (eg *EnvGetter) GetEnv(envName string) string {
 	eg.EnvName = envName
 	var ret string
 	ret, eg.Ok = os.LookupEnv(envName)
+	ret = strings.TrimSpace(ret)
 	return ret
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ func main() {
 	d := &discord.Discord{}
 
 	discordToken := env.GetEnv("DISCORD_TOKEN")
-	discordToken = strings.TrimSpace(discordToken)
 
 	debug := env.GetEnv("DEBUG")
 	debug = strings.ToLower(debug)

--- a/main.go
+++ b/main.go
@@ -8,36 +8,35 @@ import (
 	"syscall"
 
 	"github.com/naurffxiv/moddingway/internal/discord"
+	"github.com/naurffxiv/moddingway/internal/util"
 )
 
 func main() {
-	discordToken, ok := os.LookupEnv("DISCORD_TOKEN")
-	if !ok {
-		panic("You must supply a DISCORD_TOKEN to start!")
+	env := util.EnvGetter{
+		Ok: true,
 	}
-	discordToken = strings.TrimSpace(discordToken)
 
 	d := &discord.Discord{}
 
-	debug, _ := os.LookupEnv("DEBUG")
+	discordToken := env.GetEnv("DISCORD_TOKEN")
+	discordToken = strings.TrimSpace(discordToken)
+
+	debug := env.GetEnv("DEBUG")
 	debug = strings.ToLower(debug)
 
 	if debug == "true" {
-		guildID, ok := os.LookupEnv("GUILD_ID")
-		if !ok {
-			panic("You must supply a GUILD_ID to start!")
-		}
-
-		modLoggingChannelID, ok := os.LookupEnv("MOD_LOGGING_CHANNEL_ID")
-		if !ok {
-			panic("You must supply a MOD_LOGGING_CHANNEL_ID to start!")
-		}
+		guildID := env.GetEnv("GUILD_ID")
+		modLoggingChannelID := env.GetEnv("MOD_LOGGING_CHANNEL_ID")
 
 		d.Token = discordToken
 		d.GuildID = guildID
 		d.ModLoggingChannelID = modLoggingChannelID
 	} else {
 		d.Init(discordToken)
+	}
+
+	if !env.Ok { 
+		panic(fmt.Errorf("You must supply a %s to start!", env.EnvName))
 	}
 
 	fmt.Printf("Starting Discord...\n")


### PR DESCRIPTION
Currently for every environment variable we get, we need to error check like so:
```golang
discordToken, ok := os.LookupEnv("DISCORD_TOKEN")
if !ok {
  panic("You must supply a DISCORD_TOKEN to start!")
}

guildID, ok := os.LookupEnv("GUILD_ID")
if !ok {
  panic("You must supply a GUILD_ID to start!")
}

modLoggingChannelID, ok := os.LookupEnv("MOD_LOGGING_CHANNEL_ID")
if !ok {
  panic("You must supply a MOD_LOGGING_CHANNEL_ID to start!")
}

// rest of the env vars
```

This helper will allow us to simplify it slightly and move error checking to right before we start any connections.
```golang
discordToken := eg.GetEnv("DISCORD_TOKEN")
guildID := eg.GetEnv("GUILD_ID")
modLoggingChannelID := eg.GetEnv("MOD_LOGGING_CHANNEL_ID")

// rest of the env vars

if !eg.Ok {
  tempstr := fmt.Sprintf("You must supply a %s to start!", eg.EnvName)
  panic(tempstr)
}
```