### PR TITLE
Fix all current linter issues and minor ban command change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ go.work
 go.work.sum
 
 *.env
+.vscode/

--- a/internal/discord/command-handlers.go
+++ b/internal/discord/command-handlers.go
@@ -258,7 +258,10 @@ func UpdateLogMsgTimestamp(logMsg *discordgo.Message) {
 
 // RespondAndAppendLog combines both a response and a log message update into one function
 func RespondAndAppendLog(state *InteractionState, message string) {
-	RespondToInteraction(state.session, state.interaction.Interaction, message, &state.isFirst)
+	err := RespondToInteraction(state.session, state.interaction.Interaction, message, &state.isFirst)
+	if err != nil {
+		fmt.Printf("Unable to respond to interaction: %v\n", err)
+	}
 	AppendLogMsgDescription(state.logMsg, message)
 }
 

--- a/internal/discord/command-handlers.go
+++ b/internal/discord/command-handlers.go
@@ -272,16 +272,14 @@ func (d *Discord) SendDMToUser(state *InteractionState, userID string, message s
 	if err != nil {
 		tempstr := fmt.Sprintf("Could not create a DM with user %v", userID)
 		fmt.Printf("%v: %v\n", tempstr, err)
-		RespondToInteraction(state.session, state.interaction.Interaction, tempstr, &state.isFirst)
-		AppendLogMsgDescription(state.logMsg, "Failed to notify user via DM")
+		RespondAndAppendLog(state, tempstr)
 		return err
 	} else {
 		_, err = state.session.ChannelMessageSend(channel.ID, message)
 		if err != nil {
 			tempstr := fmt.Sprintf("Could not send a DM to user <@%v>", userID)
 			fmt.Printf("%v: %v\n", tempstr, err)
-			RespondToInteraction(state.session, state.interaction.Interaction, tempstr, &state.isFirst)
-			AppendLogMsgDescription(state.logMsg, "Failed to notify user via DM")
+			RespondAndAppendLog(state, tempstr)
 			return err
 		}
 		return nil

--- a/internal/discord/commands.go
+++ b/internal/discord/commands.go
@@ -73,17 +73,23 @@ func (d *Discord) Ban(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		GuildName,
 		optionMap["reason"].StringValue(),
 	)
-	d.SendDMToUser(state, userToBan, banstr)
-
-	tempstr := fmt.Sprintf("<@%v> has been banned", userToBan)
-	RespondAndAppendLog(state, tempstr)
-	d.EditLogMsg(logMsg)
+	_ = d.SendDMToUser(state, userToBan, banstr)
 
 	// Attempt to ban user
 	if len(optionMap["reason"].StringValue()) > 0 {
 		err = d.Session.GuildBanCreateWithReason(i.GuildID, userToBan, optionMap["reason"].StringValue(), 0)
+		if err != nil {
+			tempstr := fmt.Sprintf("Unable to ban user <@%v>", userToBan)
+			fmt.Printf("%v: %v\n", tempstr, err)
+			RespondAndAppendLog(state, tempstr)
+			d.EditLogMsg(logMsg)
+			return
+		}
+		tempstr := fmt.Sprintf("<@%v> has been banned", userToBan)
+		RespondAndAppendLog(state, tempstr)
+		d.EditLogMsg(logMsg)
 	} else {
-		err = StartInteraction(s, i.Interaction, "Please provide a reason for the ban.")
+		err = RespondToInteraction(s, i.Interaction, "Please provide a reason for the ban.", &state.isFirst)
 		if err != nil {
 			fmt.Printf("Unable to send ephemeral message: %v\n", err)
 		}

--- a/internal/discord/commands.go
+++ b/internal/discord/commands.go
@@ -13,7 +13,7 @@ import (
 //	user: 	User
 //	reason: string
 func (d *Discord) Kick(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+
 }
 
 // Mute attempts to mute the user specified user from the server the command was invoked in.
@@ -23,7 +23,7 @@ func (d *Discord) Kick(s *discordgo.Session, i *discordgo.InteractionCreate) {
 //	duration:	string
 //	reason:		string
 func (d *Discord) Mute(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+
 }
 
 // Unmute attempts to unmute the user specified user from the server the command was invoked in.
@@ -32,7 +32,7 @@ func (d *Discord) Mute(s *discordgo.Session, i *discordgo.InteractionCreate) {
 //	user: 		User
 //	reason:		string
 func (d *Discord) Unmute(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+
 }
 
 // Ban attempts to ban the user specified user from the server the command was invoked in.
@@ -98,7 +98,7 @@ func (d *Discord) Ban(s *discordgo.Session, i *discordgo.InteractionCreate) {
 //	user:		User
 //	reason:		string
 func (d *Discord) Unban(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // RemoveNickname attempts to remove the currently set nickname on the specified user
@@ -108,7 +108,7 @@ func (d *Discord) Unban(s *discordgo.Session, i *discordgo.InteractionCreate) {
 //	user:		User
 //	reason:		string
 func (d *Discord) RemoveNickname(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // SetNickname attempts to set the nickname of the specified user in the server
@@ -119,7 +119,7 @@ func (d *Discord) RemoveNickname(s *discordgo.Session, i *discordgo.InteractionC
 //	nickname:	string
 //	reason:		string
 func (d *Discord) SetNickname(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // Slowmode attempts to set the current channel to slowmode.
@@ -127,12 +127,12 @@ func (d *Discord) SetNickname(s *discordgo.Session, i *discordgo.InteractionCrea
 //
 //	duration:	string
 func (d *Discord) Slowmode(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // SlowmodeOff attempts to remove slowmode from the current channel.
 func (d *Discord) SlowmodeOff(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // Purge attempts to remove the last message-number messages from the specified channel.
@@ -141,7 +141,7 @@ func (d *Discord) SlowmodeOff(s *discordgo.Session, i *discordgo.InteractionCrea
 //	channel:		Channel
 //	message-number:		integer
 func (d *Discord) Purge(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // Exile attempts to add the exile role to the user, effectively soft-banning them.
@@ -307,7 +307,7 @@ func (d *Discord) SetModLoggingChannel(s *discordgo.Session, i *discordgo.Intera
 //	user:		User
 //	reason:		string
 func (d *Discord) Strike(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // ClearStrikes attempts to clear all strikes for a user.
@@ -315,7 +315,7 @@ func (d *Discord) Strike(s *discordgo.Session, i *discordgo.InteractionCreate) {
 //
 //	user:		User
 func (d *Discord) ClearStrikes(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // DeleteStrike attempts to delete a strike from a user.
@@ -323,7 +323,7 @@ func (d *Discord) ClearStrikes(s *discordgo.Session, i *discordgo.InteractionCre
 //
 //	warning_id:	integer
 func (d *Discord) DeleteStrike(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }
 
 // ShowAllStrikes attempts to show all strikes for a user.
@@ -331,5 +331,5 @@ func (d *Discord) DeleteStrike(s *discordgo.Session, i *discordgo.InteractionCre
 //
 //	user:		User
 func (d *Discord) ShowAllStrikes(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	return
+	
 }

--- a/internal/discord/commands.go
+++ b/internal/discord/commands.go
@@ -197,7 +197,7 @@ func (d *Discord) Exile(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			endTime.Unix(),
 			optionMap["reason"].StringValue(),
 		)
-		d.SendDMToUser(state, userToExile.ID, tempstr)
+		_ = d.SendDMToUser(state, userToExile.ID, tempstr)
 		d.EditLogMsg(logMsg)
 
 		time.Sleep(duration)
@@ -207,7 +207,10 @@ func (d *Discord) Exile(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		AppendLogMsgDescription(logMsg, fmt.Sprintf("Exile duration for <@%v> is over", userToExile.ID))
 		UpdateLogMsgTimestamp(logMsg)
 		if logMsg != nil {
-			d.SendEmbed(d.ModLoggingChannelID, logMsg.Embeds[0])
+			_, err = d.SendEmbed(d.ModLoggingChannelID, logMsg.Embeds[0])
+			if err != nil {
+				fmt.Printf("Unable to send embed: %v", err)
+			}
 		}
 
 		// Unexile user
@@ -221,7 +224,7 @@ func (d *Discord) Exile(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			GuildName,
 			reason,
 		)
-		d.SendDMToUser(state, userToExile.ID, tempstr)
+		_ = d.SendDMToUser(state, userToExile.ID, tempstr)
 		d.EditLogMsg(state.logMsg)
 	} else {
 		tempstr := fmt.Sprintf(
@@ -235,7 +238,7 @@ func (d *Discord) Exile(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			GuildName,
 			optionMap["reason"].StringValue(),
 		)
-		d.SendDMToUser(state, userToExile.ID, tempstr)
+		_ = d.SendDMToUser(state, userToExile.ID, tempstr)
 		d.EditLogMsg(logMsg)
 	}
 }
@@ -268,7 +271,7 @@ func (d *Discord) Unexile(s *discordgo.Session, i *discordgo.InteractionCreate) 
 		GuildName,
 		optionMap["reason"].StringValue(),
 	)
-	d.SendDMToUser(state, exiledUser.ID, tempstr)
+	_ = d.SendDMToUser(state, exiledUser.ID, tempstr)
 	d.EditLogMsg(state.logMsg)
 }
 

--- a/internal/discord/discord.go
+++ b/internal/discord/discord.go
@@ -104,24 +104,18 @@ func RespondToInteraction(s *discordgo.Session, i *discordgo.Interaction, messag
 		return err
 	}
 	if *isFirstInteraction {
-		if (3 * time.Second) <= time.Now().Sub(interactionTimestamp) {
+		if (3 * time.Second) <= time.Since(interactionTimestamp) {
 			return fmt.Errorf("initial interaction timeout")
 		}
 		err := StartInteraction(s, i, message)
-		if err != nil {
-			fmt.Printf("Unable to send initial ephemeral message: %v\n", err)
-		} else {
+		if err == nil {
 			*isFirstInteraction = false
 		}
 		return err
 	} else {
-		if (15 * time.Minute) <= time.Now().Sub(interactionTimestamp) {
+		if (15 * time.Minute) <= time.Since(interactionTimestamp) {
 			return fmt.Errorf("followup interaction timeout")
 		}
-		err := ContinueInteraction(s, i, message)
-		if err != nil {
-			fmt.Printf("Unable to send follow-up ephemeral message: %v\n", err)
-		}
-		return err
+		return ContinueInteraction(s, i, message)
 	}
 }


### PR DESCRIPTION
This PR fixes all current linter issues. It also makes a minor change to the ban command, only responding with a success after the ban is actually performed and adding an error check if it fails.

During refactoring, I'll be moving the error checking for `SendDMToUser()` to the caller, so I opted to keep the return value and use a blank identifier for the return values for now (since it currently handles errors).