### PR TITLE
Add postgres service as an option for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,8 @@ start:
 stop:
 	docker compose down
 
+test-build:
+	docker compose -f postgres.yml down
+	docker compose -f postgres.yml up --build
+
 .PHONY: format start stop

--- a/postgres.override.yml
+++ b/postgres.override.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    environment:
+      POSTGRES_HOST: postgres_local
+    depends_on:
+      postgres_local:
+        condition:
+          service_healthy
+  worker:
+    environment:
+      POSTGRES_HOST: postgres_local
+    depends_on:
+      postgres_local:
+        condition:
+          service_healthy

--- a/postgres.yml
+++ b/postgres.yml
@@ -1,0 +1,19 @@
+include:
+  - path: 
+      - docker-compose.yml
+      - postgres.override.yml
+services:
+  postgres_local:
+    container_name: postgres_db
+    image: postgres:16
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB:-moddingway}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d ${POSTGRES_DB:-moddingway} -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
This PR adds another docker compose file that overrides the main `docker-compose.yml` with additional parameters to create and point to a postgres database in the same container.
To use run `make test-build` or `docker compose -f postgres.yml up --build`. 