### PR TITLE
Add DMing user back to auto-unexile

### DIFF
--- a/internal/discord/temp.go
+++ b/internal/discord/temp.go
@@ -100,3 +100,14 @@ func CreateMemberEmbed(member *discordgo.Member, description string, footer stri
 		}
 	}
 }
+
+func (d *Discord) TempSendDMToUser(userID string, message string) error {
+	// Open DM channel with user
+	channel, err := d.Session.UserChannelCreate(userID)
+	if err != nil {
+		return err
+	} else {
+		_, err = d.Session.ChannelMessageSend(channel.ID, message)
+		return err
+	}
+}

--- a/internal/discord/temp.go
+++ b/internal/discord/temp.go
@@ -100,14 +100,3 @@ func CreateMemberEmbed(member *discordgo.Member, description string, footer stri
 		}
 	}
 }
-
-func (d *Discord) TempSendDMToUser(userID string, message string) error {
-	// Open DM channel with user
-	channel, err := d.Session.UserChannelCreate(userID)
-	if err != nil {
-		return err
-	} else {
-		_, err = d.Session.ChannelMessageSend(channel.ID, message)
-		return err
-	}
-}

--- a/internal/discord/util.go
+++ b/internal/discord/util.go
@@ -1,0 +1,11 @@
+package discord
+
+func (d *Discord) TempSendDMToUser(userID string, message string) error {
+	channel, err := d.Session.UserChannelCreate(userID)
+	if err != nil {
+		return err
+	} else {
+		_, err = d.Session.ChannelMessageSend(channel.ID, message)
+		return err
+	}
+}

--- a/internal/worker/autounexile.go
+++ b/internal/worker/autounexile.go
@@ -61,6 +61,14 @@ func processPendingUnexile(d *discord.Discord, pending database.PendingUnexile) 
 		return
 	}
 
+	// send DM to user regarding unexile
+	message := fmt.Sprintf("You have been unexiled from %v.", discord.GuildName)
+	err = d.TempSendDMToUser(pending.DiscordUserID, message)
+	if err != nil {
+		tempstr := fmt.Sprintf("Unable to send DM to user regarding unexile: %v", err)
+		printAndAppend(logMsg, tempstr, err)
+	}
+
 	logMsg.Description += "Successfully unexiled user\n"
 	removeExileEntryWrapper(d, logMsg, pending.ExileID)
 }

--- a/internal/worker/autounexile.go
+++ b/internal/worker/autounexile.go
@@ -31,9 +31,10 @@ func processPendingUnexile(d *discord.Discord, pending database.PendingUnexile) 
 	footer := fmt.Sprintf("Exile ID: %v", pending.ExileID)
 	logMsg := discord.CreateMemberEmbed(nil, description, footer)
 
-	// send the embed before returning in any branch of code
+	// remove exile entry and send the embed before returning in any branch of code
 	// return value and error not needed
 	defer func() {
+		removeExileEntryWrapper(d, logMsg, pending.ExileID)
 		_, _ = d.SendEmbed(d.ModLoggingChannelID, logMsg)
 	}()
 
@@ -42,7 +43,6 @@ func processPendingUnexile(d *discord.Discord, pending database.PendingUnexile) 
 	if err != nil {
 		tempstr := fmt.Sprintf("Could not find user <@%v> in guild", pending.DiscordUserID)
 		printAndAppend(logMsg, tempstr, err)
-		removeExileEntryWrapper(d, logMsg, pending.ExileID)
 		return
 	}
 
@@ -70,7 +70,6 @@ func processPendingUnexile(d *discord.Discord, pending database.PendingUnexile) 
 	}
 
 	logMsg.Description += "Successfully unexiled user\n"
-	removeExileEntryWrapper(d, logMsg, pending.ExileID)
 }
 
 func updateExileStatusWrapper(d *discord.Discord, logMsg *discordgo.MessageEmbed, exileID int, exileStatus enum.ExileStatus) {


### PR DESCRIPTION
Resolves #95 
Since I was here, I also deferred removing the DB entry to ensure the exile entry will get removed from the database even on errors. This will ensure that we don't try to unexile again the next time around if the exile somehow fails.