### PR TITLE
Add config.sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .vscode/
 
 /logs/*
+
+config.sh


### PR DESCRIPTION
config.sh is a file that holds all of the environment variables for testing the bot. This should not be exposed to the public as each developer's config.sh holds their discord bot token and other protected tokens. This commit removes this file from the directory all-together to ensure the safety of their discord bot tokens.