### PR TITLE
log message being appended to discord log

### DIFF
--- a/internal/discord/command-handlers.go
+++ b/internal/discord/command-handlers.go
@@ -226,6 +226,7 @@ func mapOptions(i *discordgo.InteractionCreate) map[string]*discordgo.Applicatio
 
 // AppendLogMsgDescription appends an existing logMsg with the specified text
 func AppendLogMsgDescription(logMsg *discordgo.Message, s string) {
+	log.Println(s)
 	if logMsg != nil {
 		logMsg.Embeds[0].Description += fmt.Sprintf("\n%v", s)
 	}


### PR DESCRIPTION
Log the message that is added to logging channel to the honeycomb / stdout logs
![image](https://github.com/user-attachments/assets/b240cfe0-0580-4f38-8420-8b10dbcdc1f6)
