### PR TITLE
Move is_user_moderator to util.py

### DIFF
--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -2,17 +2,10 @@ import discord
 from discord.ext.commands import Bot
 from settings import get_settings
 from services.exile_service import exile_user, unexile_user
-from util import user_has_role
-from enums import Role
+from util import is_user_moderator
 from .helper import create_logging_embed
 
 settings = get_settings()
-
-
-async def is_user_moderator(interaction: discord.Interaction):
-    return user_has_role(interaction.user, Role.ADMINISTRATION) or user_has_role(
-        interaction.user, Role.MANAGEMENT
-    )
 
 
 def create_exile_commands(bot: Bot) -> None:

--- a/src/enums.py
+++ b/src/enums.py
@@ -1,5 +1,6 @@
 from enum import StrEnum
 
+
 class Role(StrEnum):
     EXILED = "Exiled"
     VERIFIED = "Verified"

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -14,7 +14,7 @@ async def exile_user(
         logging_embed, logger, f"going to exile {user.mention} for {duration}"
     )
 
-    # Look up 
+    # Look up
 
     log_info_and_embed(logging_embed, logger, f"because {reason}")
 

--- a/src/util.py
+++ b/src/util.py
@@ -1,6 +1,7 @@
 import discord
 from settings import get_settings
 import enums
+from enums import Role
 
 settings = get_settings()
 
@@ -51,4 +52,10 @@ def user_has_role(user: discord.Member, role: enums.Role) -> bool:
         discord_role
         for discord_role in user.guild.roles
         if discord_role.name == role.value
+    )
+
+
+async def is_user_moderator(interaction: discord.Interaction):
+    return user_has_role(interaction.user, Role.ADMINISTRATION) or user_has_role(
+        interaction.user, Role.MANAGEMENT
     )


### PR DESCRIPTION
I suspect this function will be used throughout a lot more files when we add more commands, so it's better to move it out preemptively