### PR TITLE
Create reusable embed function

### DIFF
--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -22,7 +22,9 @@ def create_ban_commands(bot: Bot) -> None:
     ):
         """Ban the specified user."""
 
-        async with create_logging_embed(interaction) as logging_embed:
+        async with create_logging_embed(
+            interaction, user=user, reason=reason
+        ) as logging_embed:
             await ban_user(logging_embed, user, reason)
 
             await interaction.response.send_message(

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -4,7 +4,7 @@ from settings import get_settings
 from services.exile_service import exile_user, unexile_user
 from util import is_user_moderator, calculate_time_delta
 from typing import Optional
-from .helper import create_logging_embed, get_args
+from .helper import create_logging_embed
 
 settings = get_settings()
 

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -4,7 +4,7 @@ from settings import get_settings
 from services.exile_service import exile_user, unexile_user
 from util import is_user_moderator, calculate_time_delta
 from typing import Optional
-from .helper import create_logging_embed
+from .helper import create_logging_embed, get_args
 
 settings = get_settings()
 
@@ -16,7 +16,7 @@ def create_exile_commands(bot: Bot) -> None:
     async def unexile(interaction: discord.Interaction, user: discord.Member):
         """Unexile the specified user."""
 
-        async with create_logging_embed(interaction) as logging_embed:
+        async with create_logging_embed(interaction, get_args()) as logging_embed:
             error_message = await unexile_user(logging_embed, user)
 
             await interaction.response.send_message(
@@ -37,8 +37,7 @@ def create_exile_commands(bot: Bot) -> None:
         reason: str,
     ):
         """Exile the specified user."""
-
-        async with create_logging_embed(interaction) as logging_embed:
+        async with create_logging_embed(interaction, get_args()) as logging_embed:
             exile_duration = calculate_time_delta(duration)
             if duration and not exile_duration:
                 await interaction.response.send_message(

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -16,7 +16,7 @@ def create_exile_commands(bot: Bot) -> None:
     async def unexile(interaction: discord.Interaction, user: discord.Member):
         """Unexile the specified user."""
 
-        async with create_logging_embed(interaction, get_args()) as logging_embed:
+        async with create_logging_embed(interaction, user=user) as logging_embed:
             error_message = await unexile_user(logging_embed, user)
 
             await interaction.response.send_message(
@@ -37,7 +37,9 @@ def create_exile_commands(bot: Bot) -> None:
         reason: str,
     ):
         """Exile the specified user."""
-        async with create_logging_embed(interaction, get_args()) as logging_embed:
+        async with create_logging_embed(
+            interaction, user=user, duration=duration, reason=reason
+        ) as logging_embed:
             exile_duration = calculate_time_delta(duration)
             if duration and not exile_duration:
                 await interaction.response.send_message(

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -2,7 +2,7 @@ import sys
 from typing import Optional
 import discord
 from settings import get_settings
-from util import EmbedField, logging_embed_context
+from util import EmbedField, create_interaction_embed_context
 
 settings = get_settings()
 
@@ -19,7 +19,7 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
                 case _:
                     fields.append(EmbedField(key.title(), value))
 
-    return logging_embed_context(
+    return create_interaction_embed_context(
         interaction.guild.get_channel(settings.logging_channel_id),
         user=interaction.user,
         timestamp=interaction.created_at,

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -11,5 +11,5 @@ def create_logging_embed(interaction: discord.Interaction):
         user=interaction.user,
         timestamp=interaction.created_at,
         description=f"Used `{interaction.command.name}` command in {interaction.channel.mention}",
-        fields=[EmbedField("Action", f"/{interaction.command.name}")]
+        fields=[EmbedField("Action", f"/{interaction.command.name}")],
     )

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -7,10 +7,10 @@ from util import EmbedField, logging_embed_context
 settings = get_settings()
 
 
-def create_logging_embed(interaction: discord.Interaction, args: Optional[dict] = None):
+def create_logging_embed(interaction: discord.Interaction, **kwargs):
     fields = [EmbedField("Action", f"/{interaction.command.name}")]
-    if args is not None:
-        for key, value in args.items():
+    if kwargs is not None:
+        for key, value in kwargs.items():
             match (type(value)):
                 case discord.Member:
                     fields.append(EmbedField(key.title(), f"<@{value.id}>"))
@@ -26,11 +26,3 @@ def create_logging_embed(interaction: discord.Interaction, args: Optional[dict] 
         description=f"Used `{interaction.command.name}` command in {interaction.channel.mention}",
         fields=fields,
     )
-
-
-def get_args():
-    """Returns all arguments in the calling function except the first one (interaction)"""
-    calling_frame = sys._getframe().f_back
-    caller = calling_frame.f_code
-    relevant_vars = caller.co_varnames[: caller.co_argcount]
-    return {name: calling_frame.f_locals[name] for name in relevant_vars[1:]}

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -1,27 +1,15 @@
 import discord
 from settings import get_settings
-from contextlib import asynccontextmanager
+from util import EmbedField, create_embed
 
 settings = get_settings()
 
 
-@asynccontextmanager
-async def create_logging_embed(interaction: discord.Interaction):
-    embed = discord.Embed()
-    log_channel = interaction.guild.get_channel(settings.logging_channel_id)
-    try:
-        embed.set_author(
-            name=interaction.user.display_name,
-            icon_url=interaction.user.display_avatar.url,
-        )
-        embed.timestamp = interaction.created_at
-        embed.description = f"Used `{interaction.command.name}` command in {interaction.channel.mention}"
-        embed.add_field(name="Action", value=f"/{interaction.command.name}")
-
-        yield embed
-
-    except Exception as e:
-        embed.add_field(name="Error", value=e)
-        raise e
-    finally:
-        await log_channel.send(embed=embed)
+def create_logging_embed(interaction: discord.Interaction):
+    return create_embed(
+        interaction.guild.get_channel(settings.logging_channel_id),
+        user=interaction.user,
+        timestamp=interaction.created_at,
+        description=f"Used `{interaction.command.name}` command in {interaction.channel.mention}",
+        fields=[EmbedField("Action", f"/{interaction.command.name}")]
+    )

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -1,3 +1,5 @@
+import sys
+from typing import Optional
 import discord
 from settings import get_settings
 from util import EmbedField, create_embed
@@ -5,11 +7,30 @@ from util import EmbedField, create_embed
 settings = get_settings()
 
 
-def create_logging_embed(interaction: discord.Interaction):
+def create_logging_embed(interaction: discord.Interaction, args: Optional[dict] = None):
+    fields = [EmbedField("Action", f"/{interaction.command.name}")]
+    if args is not None:
+        for key, value in args.items():
+            match (type(value)):
+                case discord.Member:
+                    fields.append(EmbedField(key.title(), f"<@{value.id}>"))
+                case discord.ChannelType:
+                    fields.append(EmbedField(key.title(), f"<#{value}>"))
+                case _:
+                    fields.append(EmbedField(key.title(), value))
+
     return create_embed(
         interaction.guild.get_channel(settings.logging_channel_id),
         user=interaction.user,
         timestamp=interaction.created_at,
         description=f"Used `{interaction.command.name}` command in {interaction.channel.mention}",
-        fields=[EmbedField("Action", f"/{interaction.command.name}")],
+        fields=fields,
     )
+
+
+def get_args():
+    """Returns all arguments in the calling function except the first one (interaction)"""
+    calling_frame = sys._getframe().f_back
+    caller = calling_frame.f_code
+    relevant_vars = caller.co_varnames[: caller.co_argcount]
+    return {name: calling_frame.f_locals[name] for name in relevant_vars[1:]}

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -2,7 +2,7 @@ import sys
 from typing import Optional
 import discord
 from settings import get_settings
-from util import EmbedField, create_embed
+from util import EmbedField, logging_embed_context
 
 settings = get_settings()
 
@@ -19,7 +19,7 @@ def create_logging_embed(interaction: discord.Interaction, args: Optional[dict] 
                 case _:
                     fields.append(EmbedField(key.title(), value))
 
-    return create_embed(
+    return logging_embed_context(
         interaction.guild.get_channel(settings.logging_channel_id),
         user=interaction.user,
         timestamp=interaction.created_at,

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -31,7 +31,7 @@ def remove_user_exiles(user_id):
 
     with conn.get_cursor() as cursor:
         query = """
-        delete from exiles e where e.userId = %s returning *
+        delete from exiles e where e.userId = %s returning e.exileId
         """
 
         params = (user_id,)

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -31,9 +31,12 @@ def remove_user_exiles(user_id):
 
     with conn.get_cursor() as cursor:
         query = """
-        delete from exiles e where e.userId = %s
+        delete from exiles e where e.userId = %s returning *
         """
 
         params = (user_id,)
 
         cursor.execute(query, params)
+        res = cursor.fetchone()
+
+        return res[0]

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -39,4 +39,7 @@ def remove_user_exiles(user_id):
         cursor.execute(query, params)
         res = cursor.fetchone()
 
-        return res[0]
+        if res is not None:
+            return res[0]
+        else:
+            return None

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -57,6 +57,7 @@ async def exile_user(
     exile_id = exiles_database.add_exile(exile)
 
     logger.info(f"Created exile with ID {exile_id}")
+    logging_embed.set_footer(text=f"Exile ID: {exile_id}")
 
     # change user role
     await add_and_remove_role(
@@ -98,4 +99,5 @@ async def unexile_user(
 
         db_user = User(db_user_id, user.id, None, None)
 
-    exiles_database.remove_user_exiles(db_user.user_id)
+    exile_id = exiles_database.remove_user_exiles(db_user.user_id)
+    logging_embed.set_footer(text=f"Exile ID: {exile_id}")

--- a/src/util.py
+++ b/src/util.py
@@ -19,7 +19,7 @@ class EmbedField(object):
 
 
 @asynccontextmanager
-async def create_embed(log_channel: discord.abc.GuildChannel, **kwargs):
+async def logging_embed_context(log_channel: discord.abc.GuildChannel, **kwargs):
     # optional args
     user = kwargs.get("user", None)
     description = kwargs.get("description", None)

--- a/src/util.py
+++ b/src/util.py
@@ -17,14 +17,15 @@ class EmbedField(object):
         self.name = name
         self.value = value
 
+
 @asynccontextmanager
 async def create_embed(log_channel: discord.abc.GuildChannel, **kwargs):
     # optional args
-    user = kwargs.get('user', None)
-    description = kwargs.get('description', None)
-    timestamp = kwargs.get('timestamp', None)
-    footer = kwargs.get('footer', None)
-    fields = kwargs.get('fields', None)
+    user = kwargs.get("user", None)
+    description = kwargs.get("description", None)
+    timestamp = kwargs.get("timestamp", None)
+    footer = kwargs.get("footer", None)
+    fields = kwargs.get("fields", None)
 
     embed = discord.Embed()
     try:
@@ -41,11 +42,8 @@ async def create_embed(log_channel: discord.abc.GuildChannel, **kwargs):
             embed.set_footer(text=footer)
         if fields is not None:
             for field in fields:
-                embed.add_field(
-                    name=field.name,
-                    value=field.value
-                )
-        
+                embed.add_field(name=field.name, value=field.value)
+
         yield embed
     except Exception as e:
         embed.add_field(name="Error", value=e)

--- a/src/util.py
+++ b/src/util.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 import discord
 from settings import get_settings
 import re
@@ -6,6 +7,51 @@ from datetime import timedelta
 from enums import Role
 
 settings = get_settings()
+
+
+class EmbedField(object):
+    name: str
+    value: str
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+@asynccontextmanager
+async def create_embed(log_channel: discord.abc.GuildChannel, **kwargs):
+    # optional args
+    user = kwargs.get('user', None)
+    description = kwargs.get('description', None)
+    timestamp = kwargs.get('timestamp', None)
+    footer = kwargs.get('footer', None)
+    fields = kwargs.get('fields', None)
+
+    embed = discord.Embed()
+    try:
+        if user is not None:
+            embed.set_author(
+                name=user.display_name,
+                icon_url=user.display_avatar.url,
+            )
+        if description is not None:
+            embed.description = description
+        if timestamp is not None:
+            embed.timestamp = timestamp
+        if footer is not None:
+            embed.set_footer(text=footer)
+        if fields is not None:
+            for field in fields:
+                embed.add_field(
+                    name=field.name,
+                    value=field.value
+                )
+        
+        yield embed
+    except Exception as e:
+        embed.add_field(name="Error", value=e)
+        raise e
+    finally:
+        await log_channel.send(embed=embed)
 
 
 def log_info_and_embed(embed: discord.Embed, logger, message: str):

--- a/src/util.py
+++ b/src/util.py
@@ -19,7 +19,9 @@ class EmbedField(object):
 
 
 @asynccontextmanager
-async def logging_embed_context(log_channel: discord.abc.GuildChannel, **kwargs):
+async def create_interaction_embed_context(
+    log_channel: discord.abc.GuildChannel, **kwargs
+):
     # optional args
     user = kwargs.get("user", None)
     description = kwargs.get("description", None)

--- a/src/util.py
+++ b/src/util.py
@@ -42,11 +42,11 @@ async def create_embed(log_channel: discord.abc.GuildChannel, **kwargs):
             embed.set_footer(text=footer)
         if fields is not None:
             for field in fields:
-                embed.add_field(name=field.name, value=field.value)
+                embed.add_field(name=field.name, value=field.value, inline=False)
 
         yield embed
     except Exception as e:
-        embed.add_field(name="Error", value=e)
+        embed.add_field(name="Error", value=e, inline=False)
         raise e
     finally:
         await log_channel.send(embed=embed)


### PR DESCRIPTION
Adds a base function to create embeds for reusability. Updates the existing `create_logging_embed()` to use the function and adds command parameters to the embed. Additionally sets the footer to the relevant exile ID in applicable functions.
Base function will be reused with auto unexile