### PR TITLE
Add make clean to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ stop:
 install:
 	pip3 install -r requirements.txt
 
+clean:
+	docker image prune -a
+
 test-build:
 	docker compose -f postgres.yml down
 	docker compose -f postgres.yml up --build
 
-.PHONY: format start stop install
+.PHONY: format start stop install clean


### PR DESCRIPTION
As we keep running these build commands, many docker images start dangling without an attached container. Eventually this takes too much space.

This commit adds an option to "clean" out the docker images with make clean.