### PR TITLE
Add build flag to docker compose up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ python-build:
 
 python-run:
 	docker compose down
-	docker compose up python-app-local
+	docker compose up python-app-local --build
 
 database-run:
 	docker compose -f postgres.yml up -d


### PR DESCRIPTION
This commit adds the build flag to `docker compose up` to ensure that new code changes will always be included in the docker build. Without this flag, the new code will not be compiled into the build properly.