### PR TITLE
Update ban appeal DM

### DIFF
--- a/internal/discord/commands.go
+++ b/internal/discord/commands.go
@@ -44,7 +44,7 @@ func (d *Discord) Ban(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	// DM the user regarding the ban
 	banstr := fmt.Sprintf(
-		"You are being banned from `%v` for the following reason:\n> %v\nYou are able to appeal this ban through the link provided: https://dyno.gg/form/33b5a650",
+		"You are being banned from `%v` for the following reason:\n> %v\nYou are able to appeal this ban by contacting the staff team in 30 days.",
 		GuildName,
 		optionMap["reason"].StringValue(),
 	)

--- a/internal/discord/commands.go
+++ b/internal/discord/commands.go
@@ -44,7 +44,7 @@ func (d *Discord) Ban(s *discordgo.Session, i *discordgo.InteractionCreate) {
 
 	// DM the user regarding the ban
 	banstr := fmt.Sprintf(
-		"You are being banned from `%v` for the following reason:\n> %v\nYou are able to appeal this ban by contacting the staff team in 30 days.",
+		"You are being banned from `%v` for the following reason:\n> %v\nYou may appeal this ban by contacting the moderators of the server in 30 days.",
 		GuildName,
 		optionMap["reason"].StringValue(),
 	)

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -10,10 +10,11 @@ async def ban_user(logging_embed: discord.Embed, user: discord.Member, reason: s
 
     log_info_and_embed(logging_embed, logger, f"because {reason}")
 
+    #TO DO: When the appeal process is implemented, add a link to the appeal process in the message.
     await send_dm(
         user,
         f"You are being banned from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason} \
-        \nYou are able to appeal this ban through the link provided: https://dyno.gg/form/33b5a650",
+        \nYou may appeal this ban by contacting the moderators of the server in 30 days.",
     )
 
     await user.ban(reason=reason)

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -10,7 +10,7 @@ async def ban_user(logging_embed: discord.Embed, user: discord.Member, reason: s
 
     log_info_and_embed(logging_embed, logger, f"because {reason}")
 
-    #TO DO: When the appeal process is implemented, add a link to the appeal process in the message.
+    # TO DO: When the appeal process is implemented, add a link to the appeal process in the message.
     await send_dm(
         user,
         f"You are being banned from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason} \


### PR DESCRIPTION
The ban appeal process needs updated now and in the future. The dyno link no longer works so the user will need to contact one of the staff to start the appeal process.

Once the site is able to begin the appeal, process, this will need to be updated again.