### PR TITLE
Create a command to show user exiles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord
 pydantic
 psycopg2
 black
+table2ascii

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -2,7 +2,7 @@ import discord
 import logging
 from discord.ext.commands import Bot
 from settings import get_settings
-from services.exile_service import exile_user, unexile_user
+from services.exile_service import exile_user, unexile_user, get_user_exiles
 from util import is_user_moderator, calculate_time_delta
 from typing import Optional
 from .helper import create_logging_embed
@@ -93,3 +93,16 @@ def create_exile_commands(bot: Bot) -> None:
                     f"<@{interaction.user.id}> has tested their luck and lives another day...",
                     ephemeral=False,
                 )
+
+    @bot.tree.command()
+    @discord.app_commands.check(is_user_moderator)
+    @discord.app_commands.describe(user="User whose exile is being checked")
+    async def check_exile(interaction: discord.Interaction, user: discord.Member):
+        """Check the exile status of a user."""
+
+        async with create_logging_embed(interaction, user=user) as logging_embed:
+            msg = await get_user_exiles(logging_embed, user)
+
+            await interaction.response.send_message(
+                msg, ephemeral=True
+            )

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -3,7 +3,7 @@ import logging
 from discord.ext.commands import Bot
 from settings import get_settings
 from services.exile_service import exile_user, unexile_user, get_user_exiles
-from util import is_user_moderator, calculate_time_delta, log_info_and_embed
+from util import is_user_moderator, calculate_time_delta
 from typing import Optional
 from .helper import create_logging_embed
 from random import choice
@@ -40,17 +40,17 @@ def create_exile_commands(bot: Bot) -> None:
         reason: str,
     ):
         """Exile the specified user."""
+        exile_duration = calculate_time_delta(duration)
+        if duration and not exile_duration:
+            await interaction.response.send_message(
+                "Invalid exile duration given, duration should be in the form of [1 or 2 digits][s, d, m, h]. No action will be taken",
+                ephemeral=True,
+            )
+            return
+
         async with create_logging_embed(
             interaction, user=user, duration=duration, reason=reason
         ) as logging_embed:
-            exile_duration = calculate_time_delta(duration)
-            if duration and not exile_duration:
-                log_info_and_embed(logging_embed, logger, f"Parsing duration value failed, given value was {duration}")
-                await interaction.response.send_message(
-                    "Invalid exile duration given, duration should be in the form of [1 or 2 digits][s, d, m, h]. No action will be taken",
-                    ephemeral=True,
-                )
-                return
 
             error_message = await exile_user(
                 logging_embed, user, exile_duration, reason

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -103,6 +103,4 @@ def create_exile_commands(bot: Bot) -> None:
         async with create_logging_embed(interaction, user=user) as logging_embed:
             msg = await get_user_exiles(logging_embed, user)
 
-            await interaction.response.send_message(
-                msg, ephemeral=True
-            )
+            await interaction.response.send_message(msg, ephemeral=True)

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -3,7 +3,7 @@ import logging
 from discord.ext.commands import Bot
 from settings import get_settings
 from services.exile_service import exile_user, unexile_user, get_user_exiles
-from util import is_user_moderator, calculate_time_delta
+from util import is_user_moderator, calculate_time_delta, log_info_and_embed
 from typing import Optional
 from .helper import create_logging_embed
 from random import choice
@@ -45,6 +45,7 @@ def create_exile_commands(bot: Bot) -> None:
         ) as logging_embed:
             exile_duration = calculate_time_delta(duration)
             if duration and not exile_duration:
+                log_info_and_embed(logging_embed, logger, f"Parsing duration value failed, given value was {duration}")
                 await interaction.response.send_message(
                     "Invalid exile duration given, duration should be in the form of [1 or 2 digits][s, d, m, h]. No action will be taken",
                     ephemeral=True,

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -46,7 +46,7 @@ def create_exile_commands(bot: Bot) -> None:
             exile_duration = calculate_time_delta(duration)
             if duration and not exile_duration:
                 await interaction.response.send_message(
-                    "Invalid exile duration given, duration should be in the form of [1 or 2 digits][s, d, m, h]",
+                    "Invalid exile duration given, duration should be in the form of [1 or 2 digits][s, d, m, h]. No action will be taken",
                     ephemeral=True,
                 )
                 return

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -1,5 +1,4 @@
-import sys
-from typing import Optional
+import logging
 import discord
 from discord.ext.commands import Bot
 from settings import get_settings
@@ -7,6 +6,7 @@ from util import EmbedField, create_interaction_embed_context
 
 settings = get_settings()
 
+logger = logging.getLogger(__name__)
 
 def create_logging_embed(interaction: discord.Interaction, **kwargs):
     fields = [EmbedField("Action", f"/{interaction.command.name}")]
@@ -41,6 +41,7 @@ def create_bot_errors(bot: Bot) -> None:
             )
         else:
             # Handle other errors if necessary
+            logger.error(error)
             await interaction.response.send_message(
                 "An error occurred while processing the command.", ephemeral=True
             )

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -8,6 +8,7 @@ settings = get_settings()
 
 logger = logging.getLogger(__name__)
 
+
 def create_logging_embed(interaction: discord.Interaction, **kwargs):
     fields = [EmbedField("Action", f"/{interaction.command.name}")]
     if kwargs is not None:

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -2,6 +2,7 @@ from . import DatabaseConnection
 from .models import Exile, PendingExile
 from enums import ExileStatus
 from datetime import datetime, timezone
+from typing import List
 
 
 def add_exile(exile: Exile) -> int:
@@ -69,7 +70,7 @@ def get_pending_unexiles() -> list[PendingExile]:
         return [PendingExile(*x) for x in res]
 
 
-def get_user_exiles(user_id) -> PendingExile:
+def get_user_exiles(user_id) -> List[tuple]:
     conn = DatabaseConnection()
 
     with conn.get_cursor() as cursor:

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -67,3 +67,23 @@ def get_pending_unexiles() -> list[PendingExile]:
         res = cursor.fetchall()
 
         return [PendingExile(*x) for x in res]
+
+def get_user_exiles(user_id) -> PendingExile:
+    conn = DatabaseConnection()
+
+    with conn.get_cursor() as cursor:
+        query = """
+        SELECT e.exileID, e.reason, e.startTimestamp, e.endTimestamp, e.exileStatus
+        FROM exiles e
+        JOIN users u ON e.userID = u.userID
+        WHERE u.userID = %s;
+        """
+
+        params = (
+            user_id,
+        )
+
+        cursor.execute(query, params)
+        res = cursor.fetchall()
+
+        return res

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -68,6 +68,7 @@ def get_pending_unexiles() -> list[PendingExile]:
 
         return [PendingExile(*x) for x in res]
 
+
 def get_user_exiles(user_id) -> PendingExile:
     conn = DatabaseConnection()
 
@@ -79,9 +80,7 @@ def get_user_exiles(user_id) -> PendingExile:
         WHERE u.userID = %s;
         """
 
-        params = (
-            user_id,
-        )
+        params = (user_id,)
 
         cursor.execute(query, params)
         res = cursor.fetchall()

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -104,3 +104,25 @@ async def unexile_user(
     logging_embed.set_footer(text=f"Exile ID: {exile_id}")
 
     log_info_and_embed(logging_embed, logger, f"<@{user.id}> was successfully unexiled")
+
+
+async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> str:
+    db_user = users_database.get_user(user.id)
+    if db_user is None:
+        return "User not found in database"
+
+    exile_list = exiles_database.get_user_exiles(db_user.user_id)
+
+    if len(exile_list) == 0:
+        return "No exiles found for user"
+
+    # TODO convert this to an object for better stringifying
+    res = "Exiles found for the given user:\n"
+
+    for exile in exile_list:
+        res = (
+            res
+            + f"ID: `{exile[0]}`| Reason: `{exile[1]}` | start date: `{exile[2]}` | end date: `{exile[3]}` | status: `{ExileStatus(exile[4]).name}`"
+        )
+
+    return res

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -169,4 +169,4 @@ async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> s
         column_widths=[6, 58, 21, 21, 18],
     )
 
-    return f"Exiles found for the given <@{user.id}>:\n```{table_output}```"
+    return f"Exiles found for <@{user.id}>:\n```{table_output}```"

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -116,6 +116,7 @@ async def unexile_user(
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 MAX_REASON_WIDTH = 56
 
+
 async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> str:
     db_user = users_database.get_user(user.id)
     if db_user is None:
@@ -126,7 +127,6 @@ async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> s
     if len(exile_list) == 0:
         return "No exiles found for user"
 
-    
     exile = exile_list[0]
 
     exile_id = exile[0]

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -65,10 +65,16 @@ async def exile_user(
     )
 
     # message user
-    await send_dm(
-        user,
-        f"You are being exiled from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason}",
-    )
+    try:
+        await send_dm(
+            user,
+            f"You are being exiled from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason}",
+        )
+    except Exception as e:
+        log_info_and_embed(
+            logging_embed, logger, f"Failed to send DM to exiled user, {e}"
+        )
+
     log_info_and_embed(logging_embed, logger, f"<@{user.id}> was successfully exiled")
 
 

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -112,7 +112,9 @@ async def unexile_user(
 
     log_info_and_embed(logging_embed, logger, f"<@{user.id}> was successfully unexiled")
 
+
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+MAX_REASON_WIDTH = 56
 
 async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> str:
     db_user = users_database.get_user(user.id)
@@ -124,39 +126,42 @@ async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> s
     if len(exile_list) == 0:
         return "No exiles found for user"
 
+    
+    exile = exile_list[0]
+
+    exile_id = exile[0]
+    exile_reason = exile[1]
+    exile_start_date = exile[2].strftime(TIME_FORMAT)
+    exile_end_date = exile[3].strftime(TIME_FORMAT) if exile[3] else "Indefinite"
+    exile_type = ExileStatus(exile[4]).name
+
     rows = []
-    for exile in exile_list:
-        exile_id = exile[0]
-        exile_reason = exile[1]
-        exile_start_date = exile[2].strftime(TIME_FORMAT)
-        exile_end_date = exile[3].strftime(TIME_FORMAT) if exile[3] else "Indefinite"
-        exile_type = ExileStatus(exile[4]).name
-        # Break long exile messages into multiple rows so that formatting in discord message doesn't wrap
-        # These column sizes don't wrap when viewing discord on a 1080p monitor with sidebars opened
-        if len(exile_start_date) < 56:
-            rows.append(
-                [
-                    exile_id,
-                    exile_reason,
-                    exile_start_date,
-                    exile_end_date,
-                    exile_type,
-                ]
-            )
-        else:
-            rows.append(
-                [
-                    exile_id,
-                    exile_reason[:56],
-                    exile_start_date,
-                    exile_end_date,
-                    exile_type,
-                ]
-            )
-            i = 56
-            while i < len(exile_reason):
-                rows.append(["", exile_reason[i : i + 56], "", "", ""])
-                i = i + 56
+    # Break long exile messages into multiple rows so that formatting in discord message doesn't wrap
+    # These column sizes don't wrap when viewing discord on a 1080p monitor with sidebars opened
+    if len(exile_reason) < 56:
+        rows.append(
+            [
+                exile_id,
+                exile_reason,
+                exile_start_date,
+                exile_end_date,
+                exile_type,
+            ]
+        )
+    else:
+        rows.append(
+            [
+                exile_id,
+                exile_reason[:56],
+                exile_start_date,
+                exile_end_date,
+                exile_type,
+            ]
+        )
+        i = MAX_REASON_WIDTH
+        while i < len(exile_reason):
+            rows.append(["", exile_reason[i : i + MAX_REASON_WIDTH], "", "", ""])
+            i = i + MAX_REASON_WIDTH
 
     table_output = table2ascii(
         header=["ID", "Reason", "Start Date", "End Date", "Status"],


### PR DESCRIPTION
* Create command to show user's exiles
* When parsing duration fails on exile command, clearly state that the user will not be exiled
* Do not create log when parsing exile duration fails
* Try/catch around sending user DMs, since failures are expected when user blocks DMs

Screenshot is taken on a 1080p monitor with both discord sidebars open, not sure if there's a better way to handle long reason messages. Lorem ipsum example is 508 characters long

![image](https://github.com/user-attachments/assets/8082f295-fad3-4458-9075-b8efbae979aa)

![image](https://github.com/user-attachments/assets/0c1b855a-964b-4e2a-abf0-22bd3e9fa0f2)

![image](https://github.com/user-attachments/assets/9648783e-e6ab-440f-8f3e-47f6734fee93)

Ticket: MWAY-13 MWAY-4