### PR TITLE
Delete threads that do not meet activity requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Postgres-related information is configured in the environment variables instead 
 - DEBUG
 - GUILD_ID
 - MOD_LOGGING_CHANNEL_ID
+- INACTIVE_FORUM_CHANNEL_ID
+- INACTIVE_FORUM_DURATION
 
 `DEBUG` must be set to `true` for testing.  
 Defaults are also set for `POSTGRES_PORT` (5432) and `POSTGRES_DB` (moddingway) if those two are not set.
+`INACTIVE_FORUM_CHANNEL_ID` and `INACTIVE_FORUM_DURATION` are optional. The relevant task will not run if those environment variables are not defined.

--- a/src/settings.py
+++ b/src/settings.py
@@ -15,6 +15,7 @@ class Settings(BaseModel):
     database_name: str = "moddingway"
     postgres_username: str = os.environ["POSTGRES_USER"]
     postgres_password: str = os.environ["POSTGRES_PASSWORD"]
+    automod_inactivity: dict[int, int]  # key: channel id, value: inactive limit (days)
 
 
 def prod() -> Settings:
@@ -24,16 +25,30 @@ def prod() -> Settings:
         log_level=logging.INFO,
         postgres_host=os.environ.get("POSTGRES_HOST"),
         postgres_port=os.environ.get("POSTGRES_PORT"),
+        automod_inactivity={
+            1273263026744590468: 30,
+            1273261496968810598: 30,
+            1240356145311252615: 15,
+        },
     )
 
 
 def local() -> Settings:
+    inactive_forum_channel_id = os.environ.get("INACTIVE_FORUM_CHANNEL_ID")
+    inactive_forum_duration = os.environ.get("INACTIVE_FORUM_DURATION")
+
+    if inactive_forum_channel_id is not None and inactive_forum_duration is not None:
+        automod_inactivity = {inactive_forum_channel_id: inactive_forum_duration}
+    else:
+        automod_inactivity = {}
+
     return Settings(
         guild_id=int(os.environ["GUILD_ID"]),
         logging_channel_id=int(os.environ["MOD_LOGGING_CHANNEL_ID"]),
         log_level=logging.DEBUG,
         postgres_host=os.environ.get("POSTGRES_HOST", "localhost"),
         postgres_port=os.environ.get("POSTGRES_PORT", "5432"),
+        automod_inactivity=automod_inactivity,
     )
 
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -26,9 +26,11 @@ def prod() -> Settings:
         postgres_host=os.environ.get("POSTGRES_HOST"),
         postgres_port=os.environ.get("POSTGRES_PORT"),
         automod_inactivity={
-            1273263026744590468: 30,
-            1273261496968810598: 30,
-            1240356145311252615: 15,
+            1273263026744590468: 30,  # lfg
+            1273261496968810598: 30,  # lfm
+            1240356145311252615: 30,  # temporary
+            1301166606985990144: 7,  # FRU
+            1300527846468616302: 7,  # scheduled legacy
         },
     )
 

--- a/src/workers/__init__.py
+++ b/src/workers/__init__.py
@@ -1,6 +1,8 @@
 from discord.ext.commands import Bot
 from .autounexile import autounexile_users
+from .forum_automod import autodelete_threads
 
 
 def start_tasks(self):
     autounexile_users.start(self)
+    autodelete_threads.start(self)

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -59,12 +59,23 @@ async def autodelete_threads(self):
 
                     # TODO: uncomment DM portion and sleep when backlog is dealt with
                     # if thread.owner is not None:
-                    #     await send_dm(
-                    #         thread.owner,
-                    #         f'Your thread "{thread.name}" in <#{channel_id}> has been automatically deleted as {duration} days have passed without any activity or the starter message has been deleted.',
-                    #     )
+                    #     try:
+                    #         await send_dm(
+                    #             thread.owner,
+                    #             f'Your thread "{thread.name}" in <#{channel_id}> has been automatically deleted as {duration} days have passed without any activity or the starter message has been deleted.',
+                    #         )
+                    #     except discord.Forbidden:
+                    #         log_info_and_embed(
+                    #             automod_embed,
+                    #             logger,
+                    #             "Unable to DM user, user has DMs disabled.",
+                    #         )
                     # else:
-                    #     log_info_and_embed(automod_embed, logger, "Unable to DM user, user is not in the server anymore.")
+                    #     log_info_and_embed(
+                    #         automod_embed,
+                    #         logger,
+                    #         "Unable to DM user, user is not in the server anymore.",
+                    #     )
             except Exception as e:
                 logger.error(e)
             # await asyncio.sleep(300)

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -25,8 +25,8 @@ async def autodelete_threads(self):
             continue
 
         for thread in channel.threads:
-            # skip the for loop if the thread is pinned
             if thread.flags.pinned:
+                # skip the for loop if the thread is pinned
                 continue
 
             # check if starter message was deleted
@@ -64,7 +64,7 @@ async def autodelete_threads(self):
                     #         f'Your thread "{thread.name}" in <#{channel_id}> has been automatically deleted as {duration} days have passed without any activity or the starter message has been deleted.',
                     #     )
                     # else:
-                    #     log_info_and_embed(automod_embed, logger, "Unable to DM user.")
+                    #     log_info_and_embed(automod_embed, logger, "Unable to DM user, user is not in the server anymore.")
             except Exception as e:
                 logger.error(e)
             # await asyncio.sleep(300)

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -25,8 +25,7 @@ async def autodelete_threads(self):
             continue
 
         for thread in channel.threads:
-            last_post = thread.last_message_id
-
+            # skip the for loop if the thread is pinned
             if thread.flags.pinned:
                 continue
 
@@ -41,6 +40,7 @@ async def autodelete_threads(self):
                 logger.error(e)
 
             now = datetime.now(timezone.utc)
+            last_post = thread.last_message_id
             time_since = now - snowflake_time(last_post)
             if starter_message is not None and time_since < timedelta(days=duration):
                 continue

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timezone, timedelta
+import discord
+import logging
+import asyncio
+from settings import get_settings
+from util import log_info_and_embed, send_dm
+from .helper import create_automod_embed
+from discord.ext import tasks
+from discord.utils import snowflake_time
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+
+@tasks.loop(hours=24)
+async def autodelete_threads(self):
+    guild = self.get_guild(settings.guild_id)
+    if guild is None:
+        return
+
+    for channel_id, duration in settings.automod_inactivity.items():
+        channel = guild.get_channel(channel_id)
+        if channel is None:
+            continue
+
+        for thread in channel.threads:
+            last_post = thread.last_message_id
+
+            if thread.flags.pinned:
+                continue
+
+            # check if starter message was deleted
+            starter_message = None
+            try:
+                starter_message = await thread.fetch_message(thread.id)
+                await asyncio.sleep(0.5)
+            except discord.NotFound:
+                pass
+            except Exception as e:
+                logger.error(e)
+
+            now = datetime.now(timezone.utc)
+            time_since = now - snowflake_time(last_post)
+            if starter_message is not None and time_since < timedelta(days=duration):
+                continue
+
+            # delete thread and try to send DM to user
+            try:
+                async with create_automod_embed(
+                    self,
+                    thread,
+                    now,
+                ) as automod_embed:
+                    await thread.delete()
+                    log_info_and_embed(
+                        automod_embed, logger, "Thread has been deleted successfully."
+                    )
+
+                    # TODO: uncomment DM portion and sleep when backlog is dealt with
+                    # if thread.owner is not None:
+                    #     await send_dm(
+                    #         thread.owner,
+                    #         f'Your thread "{thread.name}" in <#{channel_id}> has been automatically deleted as {duration} days have passed without any activity or the starter message has been deleted.',
+                    #     )
+                    # else:
+                    #     log_info_and_embed(automod_embed, logger, "Unable to DM user.")
+            except Exception as e:
+                logger.error(e)
+            # await asyncio.sleep(300)

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 async def autodelete_threads(self):
     guild = self.get_guild(settings.guild_id)
     if guild is None:
+        logger.error("Guild not found.")
         return
 
     for channel_id, duration in settings.automod_inactivity.items():

--- a/src/workers/helper.py
+++ b/src/workers/helper.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 import discord
 from discord.ext.commands import Bot
 from settings import get_settings
 from util import create_interaction_embed_context
+from typing import Optional
 
 settings = get_settings()
 
@@ -15,4 +17,13 @@ def create_autounexile_embed(
         timestamp=end_timestamp,
         description=f"<@{user.id}>'s exile has timed out",
         footer=f"Exile ID: {exile_id}",
+    )
+
+
+def create_automod_embed(self, thread: discord.Thread, timestamp: datetime):
+    return create_interaction_embed_context(
+        self.get_channel(settings.logging_channel_id),
+        user=thread.owner,
+        timestamp=timestamp,
+        description=f'<@{thread.owner_id}>\'s thread, "{thread.name}", meets the requirements for automod deletion.',
     )


### PR DESCRIPTION
Ticket: [MWAY-15](https://naurffxiv.atlassian.net/browse/MWAY-15)
Adds a task that runs once every 24 hours that checks threads for activity requirements. Additionally, the task also checks if the starter message is present. If the thread doesn't meet either requirements, it's deleted and a DM will be sent (commented out for now to deal with backlog present in NAUR) to the original owner. A log will also be made upon each deletion.

In debug mode, it will check for the `INACTIVE_FORUM_CHANNEL_ID` and `INACTIVE_FORUM_DURATION` environment variables.

# Log message
![image](https://github.com/user-attachments/assets/6083dcee-6eb9-4586-b07b-c2b325ba9f2a)

# DM
![image](https://github.com/user-attachments/assets/5946ce98-03ea-4f0c-95db-7ecba1a3d45b)


[MWAY-15]: https://naurffxiv.atlassian.net/browse/MWAY-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ