### PR TITLE
Fix autounexile looping on fail

### DIFF
--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -27,6 +27,4 @@ def create_ban_commands(bot: Bot) -> None:
             ) as logging_embed:
                 await ban_user(logging_embed, user, reason)
 
-                response_message.set_string(
-                    f"Successfully banned {user.mention}", ephemeral=True
-                )
+                response_message.set_string(f"Successfully banned {user.mention}")

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -53,7 +53,7 @@ def get_pending_unexiles() -> list[PendingExile]:
 
     with conn.get_cursor() as cursor:
         query = """
-        SELECT e.exileID, u.discordUserID, e.endTimestamp
+        SELECT e.exileID, u.userID, u.discordUserID, e.endTimestamp
         FROM exiles e
         JOIN users u ON e.userID = u.userID
         WHERE e.exileStatus = %s AND e.endTimestamp < %s;

--- a/src/database/exiles_database.py
+++ b/src/database/exiles_database.py
@@ -29,6 +29,26 @@ def add_exile(exile: Exile) -> int:
         return res[0]
 
 
+def update_exile_status(exile_id, exile_status):
+    conn = DatabaseConnection()
+
+    with conn.get_cursor() as cursor:
+        query = """
+        UPDATE exiles
+        SET exileStatus = %s
+        WHERE exileID = %s
+        """
+
+        params = (
+            exile_status,
+            exile_id,
+        )
+
+        cursor.execute(query, params)
+
+        return
+
+
 def remove_user_exiles(user_id):
     conn = DatabaseConnection()
 
@@ -87,3 +107,26 @@ def get_user_exiles(user_id) -> List[tuple]:
         res = cursor.fetchall()
 
         return res
+
+
+def get_user_active_exile(user_id) -> PendingExile:
+    conn = DatabaseConnection()
+
+    with conn.get_cursor() as cursor:
+        query = """
+        SELECT e.exileID, u.userID, u.discordUserID, e.endTimestamp
+        FROM exiles e
+        JOIN users u ON e.userID = u.userID
+        WHERE u.userID = %s AND  (e.exileStatus = %s OR e.exileStatus = %s)
+        LIMIT 1;
+        """
+
+        params = (user_id, ExileStatus.TIMED_EXILED, ExileStatus.INDEFINITE_EXILE)
+
+        cursor.execute(query, params)
+        res = cursor.fetchone()
+
+        if res is not None:
+            return PendingExile(*res)
+        else:
+            return None

--- a/src/database/models/pending_exile.py
+++ b/src/database/models/pending_exile.py
@@ -1,5 +1,6 @@
 class PendingExile(object):
-    def __init__(self, exile_id, user_id, end_timestamp):
+    def __init__(self, exile_id, user_id, discord_id, end_timestamp):
         self.exile_id = int(exile_id)
         self.user_id = int(user_id)
+        self.discord_id = int(discord_id)
         self.end_timestamp = end_timestamp

--- a/src/enums.py
+++ b/src/enums.py
@@ -13,3 +13,4 @@ class ExileStatus(IntEnum):
     INDEFINITE_EXILE = 0
     TIMED_EXILED = 1
     UNEXILED = 2
+    UNKNOWN = 3

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -107,8 +107,16 @@ async def unexile_user(
 
         db_user = User(db_user_id, user.id, None, None)
 
-    exile_id = exiles_database.remove_user_exiles(db_user.user_id)
-    logging_embed.set_footer(text=f"Exile ID: {exile_id}")
+    exile = exiles_database.get_user_active_exile(db_user.user_id)
+
+    if exile is None:
+        # This should only happen when someone was manually exiled then unexiled through the bot
+        logger.info(
+            f"No active exile associated with user ID {db_user.user_id} was found. Skipping DB actions..."
+        )
+    else:
+        exiles_database.update_exile_status(exile.exile_id, ExileStatus.UNEXILED)
+        logging_embed.set_footer(text=f"Exile ID: {exile.exile_id}")
 
     log_info_and_embed(logging_embed, logger, f"<@{user.id}> was successfully unexiled")
 

--- a/src/workers/autounexile.py
+++ b/src/workers/autounexile.py
@@ -1,9 +1,9 @@
 from discord.ext import tasks
-from discord.ext.commands import Bot
 from database import exiles_database
 from services.exile_service import unexile_user
 from settings import get_settings
 from .helper import create_autounexile_embed
+from enums import ExileStatus
 import logging
 
 settings = get_settings()
@@ -33,6 +33,6 @@ async def autounexile_users(self):
                 raise Exception(error_message)
         except Exception:
             logger.info(
-                f"Auto Unexile failed, removing exile entry {exile.exile_id}: user {exile.discord_id}"
+                f"Auto Unexile failed, updating exile status of exile {exile.exile_id}, user {exile.discord_id} to unknown"
             )
-            exiles_database.remove_user_exiles(exile.user_id)
+            exiles_database.update_exile_status(exile.exile_id, ExileStatus.UNKNOWN)

--- a/src/workers/autounexile.py
+++ b/src/workers/autounexile.py
@@ -16,15 +16,21 @@ async def autounexile_users(self):
 
     for exile in exiles:
         logger.info(f"Auto Unexile running on user id {exile.user_id}")
-        member = self.get_guild(settings.guild_id).get_member(exile.user_id)
-        if member is not None:
-            async with create_autounexile_embed(
-                self, member, exile.exile_id, exile.end_timestamp
-            ) as autounexile_embed:
-                await unexile_user(autounexile_embed, member)
-        else:
-            logger.error(f"User {exile.user_id} not found in server")
+        try:
+            error_message = None
+            member = self.get_guild(settings.guild_id).get_member(exile.discord_id)
 
-        exiles_database.remove_user_exiles(
-            exile.user_id
-        )  # remove entry from database no matter what
+            async with create_autounexile_embed(
+                self, member, exile.discord_id, exile.exile_id, exile.end_timestamp
+            ) as autounexile_embed:
+                if member is None:
+                    error_message = f"<@{exile.discord_id}> was not found in the server"
+                    logger.info(error_message)
+                    raise Exception(error_message)
+
+                error_message = await unexile_user(autounexile_embed, member)
+            if error_message is not None:
+                raise Exception(error_message)
+        except Exception:
+            logger.info(f"Auto Unexile failed, removing exile entry {exile.exile_id}")
+            exiles_database.remove_user_exiles(exile.user_id)

--- a/src/workers/autounexile.py
+++ b/src/workers/autounexile.py
@@ -32,5 +32,7 @@ async def autounexile_users(self):
             if error_message is not None:
                 raise Exception(error_message)
         except Exception:
-            logger.info(f"Auto Unexile failed, removing exile entry {exile.exile_id}")
+            logger.info(
+                f"Auto Unexile failed, removing exile entry {exile.exile_id}: user {exile.discord_id}"
+            )
             exiles_database.remove_user_exiles(exile.user_id)

--- a/src/workers/helper.py
+++ b/src/workers/helper.py
@@ -2,17 +2,18 @@ import discord
 from discord.ext.commands import Bot
 from settings import get_settings
 from util import create_interaction_embed_context
+from typing import Optional
 
 settings = get_settings()
 
 
 def create_autounexile_embed(
-    self, user: discord.User, exile_id: str, end_timestamp: str
+    self, user: Optional[discord.Member], discord_id, exile_id: str, end_timestamp: str
 ):
     return create_interaction_embed_context(
         self.get_channel(settings.logging_channel_id),
         user=user,
         timestamp=end_timestamp,
-        description=f"<@{user.id}>'s exile has timed out",
+        description=f"<@{discord_id}>'s exile has timed out",
         footer=f"Exile ID: {exile_id}",
     )

--- a/src/workers/helper.py
+++ b/src/workers/helper.py
@@ -8,7 +8,11 @@ settings = get_settings()
 
 
 def create_autounexile_embed(
-    self, user: Optional[discord.Member], discord_id, exile_id: str, end_timestamp: str
+    self,
+    user: Optional[discord.Member],
+    discord_id: int,
+    exile_id: str,
+    end_timestamp: str,
 ):
     return create_interaction_embed_context(
         self.get_channel(settings.logging_channel_id),


### PR DESCRIPTION
Ticket: MOD-14
This PR fixes a bug where autounexile did not remove exile entries upon failure and now additionally properly handles cases where the user left during the timed exile. It also fixes a minor typo in the ban command.

[MWAY-26]: https://naurffxiv.atlassian.net/browse/MWAY-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ