### PR TITLE
Condense automod logs

### DIFF
--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -82,7 +82,13 @@ async def autodelete_threads(self):
                 logger.error(e)
                 num_error += 1
             # await asyncio.sleep(300)
-        async with create_automod_embed(
-            self, channel_id, num_removed, num_error, datetime.now(timezone.utc)
-        ):
-            pass
+        if num_removed > 0 or num_error > 0:
+            logger.info(
+                f"Removed a total of {num_removed} threads from channel {channel_id}. {num_error} failed removals."
+            )
+            async with create_automod_embed(
+                self, channel_id, num_removed, num_error, datetime.now(timezone.utc)
+            ):
+                pass
+        else:
+            logger.info(f"No threads were marked for deletion in channel {channel_id}.")

--- a/src/workers/helper.py
+++ b/src/workers/helper.py
@@ -20,10 +20,10 @@ def create_autounexile_embed(
     )
 
 
-def create_automod_embed(self, thread: discord.Thread, timestamp: datetime):
+def create_automod_embed(self, channel_id, num_removed, num_error, timestamp: datetime):
     return create_interaction_embed_context(
         self.get_channel(settings.logging_channel_id),
-        user=thread.owner,
+        user=self.user,
         timestamp=timestamp,
-        description=f'<@{thread.owner_id}>\'s thread, "{thread.name}", meets the requirements for automod deletion.',
+        description=f"Successfully removed {num_removed} inactive thread(s) from <#{channel_id}>.\n{num_error} inactive thread(s) failed to be removed.",
     )


### PR DESCRIPTION
Condenses automod logs from a per-thread basis to a per-forum channel basis.
# Preview of embed
![image](https://github.com/user-attachments/assets/9975eb8e-9ac9-4761-ab59-974de85f3e6d)
First embed: Failed DM, per person (on failed DM)
Second embed: Total stats, per forum channel