### PR TITLE
Max character ban fail fix old

### DIFF
--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -21,12 +21,13 @@ def create_ban_commands(bot: Bot) -> None:
         reason: str,
     ):
         """Ban the specified user."""
+        #result is a tuple of state and descriptio
+        result = await ban_user(user, reason)
 
-        async with create_logging_embed(
-            interaction, user=user, reason=reason
-        ) as logging_embed:
-            await ban_user(logging_embed, user, reason)
-
-            await interaction.response.send_message(
-                f"Successfully banned {user.mention}", ephemeral=True
-            )
+        if result[0]: #ban succeeded dont create embed.
+            async with create_logging_embed(
+                interaction, user=user, reason=reason
+            ) as logging_embed:
+                await interaction.response.send_message(result[1], ephemeral=True)
+        else: #ban failed, dont create embed
+            await interaction.response.send_message(result[1], ephemeral=True)

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -25,9 +25,15 @@ def create_ban_commands(bot: Bot) -> None:
         result = await ban_user(user, reason)
 
         if result[0]: #ban succeeded dont create embed.
-            async with create_logging_embed(
-                interaction, user=user, reason=reason
-            ) as logging_embed:
-                await interaction.response.send_message(result[1], ephemeral=True)
+            if not result[1]: #dm failed 
+                async with create_logging_embed(
+                    interaction, user=user, reason=reason, error = result[2]
+                ) as logging_embed:
+                    await interaction.response.send_message(result[2], ephemeral=True)
+            else: #ban succeeded, dm failed. 
+                async with create_logging_embed(
+                    interaction, user=user, reason=reason, result = result[2]
+                ) as logging_embed:
+                    await interaction.response.send_message(result[2], ephemeral=True)
         else: #ban failed, dont create embed
-            await interaction.response.send_message(result[1], ephemeral=True)
+            await interaction.response.send_message(result[2], ephemeral=True)

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -11,7 +11,19 @@ logger = logging.getLogger(__name__)
 async def ban_user(
     user: discord.Member, 
     reason: str
-) -> Optional[Tuple[bool, str]]:
+) -> Optional[Tuple[bool, bool, str]]:
+    """Executes ban of user
+
+    Args:
+        user (discord.Member): mention or "@"/user ID of the user being banned.
+        reason (str): description of ban reason.
+
+    Returns:
+        Optional[Tuple[bool, bool, str]]: tuple containing (result,dm_state,result_description)
+            - result (bool): Indicates whether the ban succeeded.
+            - dm_state (bool): Indicates whether the DM notification to the user succeeded.
+            - result_description (str): A message describing the status of the ban operation.
+    """
     if len(reason) < 512: 
         
         result_description = ""
@@ -23,46 +35,47 @@ async def ban_user(
                 f"You are being banned from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason} "
                 "\nYou may appeal this ban by contacting the moderators of the server in 30 days."
             )
-            dm_info = f"DM sent to {user.mention} with ban reason."
-            logger.info("Successfully sent dm to user")
+            logger.info(f"Successfully sent dm to {user.mention}")
             dm_state = True
         except discord.Forbidden as e:
-            dm_info = f"Could not send DM to {user.mention} (DMs disabled or bot blocked)."
-            logger.info(f"DM failed to send due to permission error: {e}")
+            logger.error(f"DM to {user.mention} failed due to permission error: {e}")
             dm_state = False
         except discord.HTTPException as e:
-            dm_info = f"Failed to send DM to {user.mention} due to an HTTP error: {e}."
-            logger.info(f"DM failed to send due to HTTP Error: {e}")
+            logger.error(f"DM to {user.mention} due to HTTP Error: {e}")
+            dm_state = False
+        except Exception as e:
+            logger.error(f"DM to {user.mention} due to Unknown Error: {e}")
             dm_state = False
 
         #attempt Ban
         try:
             await user.ban(reason=reason)
-            logger.info("Successfully banned")
-            ban_info = f"Successfully banned {user.mention}."
+            logger.info(f"Successfully banned {user.mention}")
             result = True
         except discord.Forbidden as e:
-            ban_info = f" Failed to ban {user.mention}; insufficient permissions."
-            logger.info(f"Ban failed due to permission error: {e}")
+            logger.error(f"Ban of {user.mention} failed due to permission error: {e}")
             result = False
         except discord.HTTPException as e:
-            ban_info = f" An error occurred while banning {user.mention}: {e}."
-            logger.info(f"Ban failed due to HTTP Error: {e}")
+            logger.error(f"Ban of {user.mention} failed due to HTTP Error: {e}")
             result = False
-            
+        except Exception as e:
+            logger.error(f"Ban of {user.mention} failed due to Unknown Error: {e}")
+            result = False
     
         if not result and dm_state: #ban fail dm succeed.
-            result_description = ban_info + "\n" + dm_info + "\n" + "Ban failed but DM sent, please ban via alternative means."
+            result_description =  f"Unable to ban {user.mention}, please ban via discord built-in ban feature. A DM has been sent to {user.mention} with ban reason."
         elif result and not dm_state: #ban succeed dm fail.
-            result_description = ban_info + "\n" + dm_info + "\n" + "Ban succeeded but DM failed to send."
-        else: #either both fail or both succeed.
-            result_description = ban_info + "\n" + dm_info
+            result_description = f"Successfully banned {user.mention} but DM failed to send."
+        elif result and dm_state: #full success
+            result_description = f"Successfully banned {user.mention} and DM has been sent with ban reason."
+        else: #full failure
+            result_description = f"Unable to ban {user.mention} and unable to send DM. Please ban via discord built-in ban feature or try again later."
 
     else:
         #reason too large, ban action canceled.
         result_description = f"Unable to ban: {user.mention}, reason given is too long (above 512 characters). Please shorten ban reason."
         result = False
     #always return this.    
-    return (result,result_description)
+    return (result,dm_state,result_description)
         
     

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -1,20 +1,68 @@
 import discord
 import logging
+from typing import Optional,Tuple
 from util import log_info_and_embed, send_dm
+from settings import get_settings
 
+settings = get_settings()
 logger = logging.getLogger(__name__)
 
 
-async def ban_user(logging_embed: discord.Embed, user: discord.Member, reason: str):
-    log_info_and_embed(logging_embed, logger, f"going to ban {user.mention}")
+async def ban_user(
+    user: discord.Member, 
+    reason: str
+) -> Optional[Tuple[bool, str]]:
+    if len(reason) < 512: 
+        
+        result_description = ""
+        dm_state = False
+        #attempt to send a DM to the user with the reason for the ban
+        try:
+            await send_dm(
+                user,
+                f"You are being banned from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason} "
+                "\nYou may appeal this ban by contacting the moderators of the server in 30 days."
+            )
+            dm_info = f"DM sent to {user.mention} with ban reason."
+            logger.info("Successfully sent dm to user")
+            dm_state = True
+        except discord.Forbidden as e:
+            dm_info = f"Could not send DM to {user.mention} (DMs disabled or bot blocked)."
+            logger.info(f"DM failed to send due to permission error: {e}")
+            dm_state = False
+        except discord.HTTPException as e:
+            dm_info = f"Failed to send DM to {user.mention} due to an HTTP error: {e}."
+            logger.info(f"DM failed to send due to HTTP Error: {e}")
+            dm_state = False
 
-    log_info_and_embed(logging_embed, logger, f"because {reason}")
+        #attempt Ban
+        try:
+            await user.ban(reason=reason)
+            logger.info("Successfully banned")
+            ban_info = f"Successfully banned {user.mention}."
+            result = True
+        except discord.Forbidden as e:
+            ban_info = f" Failed to ban {user.mention}; insufficient permissions."
+            logger.info(f"Ban failed due to permission error: {e}")
+            result = False
+        except discord.HTTPException as e:
+            ban_info = f" An error occurred while banning {user.mention}: {e}."
+            logger.info(f"Ban failed due to HTTP Error: {e}")
+            result = False
+            
+    
+        if not result and dm_state: #ban fail dm succeed.
+            result_description = ban_info + "\n" + dm_info + "\n" + "Ban failed but DM sent, please ban via alternative means."
+        elif result and not dm_state: #ban succeed dm fail.
+            result_description = ban_info + "\n" + dm_info + "\n" + "Ban succeeded but DM failed to send."
+        else: #either both fail or both succeed.
+            result_description = ban_info + "\n" + dm_info
 
-    # TO DO: When the appeal process is implemented, add a link to the appeal process in the message.
-    await send_dm(
-        user,
-        f"You are being banned from NA Ultimate Raiding - FF XIV for the following reason: \n> {reason} \
-        \nYou may appeal this ban by contacting the moderators of the server in 30 days.",
-    )
-
-    await user.ban(reason=reason)
+    else:
+        #reason too large, ban action canceled.
+        result_description = f"Unable to ban: {user.mention}, reason given is too long (above 512 characters). Please shorten ban reason."
+        result = False
+    #always return this.    
+    return (result,result_description)
+        
+    


### PR DESCRIPTION
Handles the 512 reason character error and standardizes the messages and embeds.

- Embeds happen when a ban succeeds
- Notes whether or not a DM succeeds or fails
- Ephemeral messages are always sent, including ban status and dm status, and match the error/result given in an embed if it exists.
- Correctly logs output for backend debugging.