### PR TITLE
Fix PR ticket check

### DIFF
--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -13,15 +13,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TICKET_PATTERN="^\s*(Ticket:\s*)?([A-Z]+-[0-9]+|NA)\s*$"
+          TICKET_PATTERN="^\s*((T|t)((icket)|(ICKET)):\s*)?([A-Z]+-[0-9]+|NA)\s*$"
+          match=false
 
           pr_description=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }} | jq -r .body)
 
-          if [[ ! "$pr_description" =~ $TICKET_PATTERN ]]; then
-            echo "The pull request description does not contain a valid ticket number or 'Ticket: NA'."
-            exit 1
-          fi
+          readarray -t description_split <<<"${pr_description//'\r\n'/$'\n'}"
 
-          echo "The pull request description contains a valid ticket format or 'Ticket: NA'."
+          for line in "${description_split[@]}"; do
+              if [[ "$line" =~ $TICKET_PATTERN ]]; then
+                  echo "The pull request description contains a valid ticket format or 'Ticket: NA'."
+                  exit 0
+              fi
+          done
+          
+          echo "The pull request description does not contain a valid ticket number or 'Ticket: NA'."
+          exit 1


### PR DESCRIPTION
Ticket: NA
Updates the check to process each line as a separate string so the literal `\r\n` in which the PR is received doesn't matter.
Also now accepts either `Ticket`, `TICKET`, or `ticket`