### PR TITLE
Tag commits

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -1,0 +1,17 @@
+name: Automated Tagging
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set version number
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git tag -a "1.1.${{ github.run_number }}" -m "Release 1.1.${{ github.run_number }}"
+        git push origin "1.1.${{ github.run_number }}"


### PR DESCRIPTION
As we want to see what goes into each release, we should label each commit with a tag to make finding out the release content easier.

Ticket: MOD-51