### PR TITLE
Update timestamp for cooldown period

### DIFF
--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -37,10 +37,9 @@ def create_bot_errors(bot: Bot) -> None:
     async def on_app_command_error(interaction: discord.Interaction, error):
         # Check if the error is due to a cooldown
         if isinstance(error, discord.app_commands.CommandOnCooldown):
-            current_time = int(time.time())
-            remaining_time = int(error.retry_after)
+            remaining_time = int(error.retry_after) + int(time.time())
             await interaction.response.send_message(
-                f"This command is on cooldown. Time remaining: <t:{remaining_time + current_time}:R>",
+                f"This command is on cooldown. Time remaining: <t:{remaining_time}:R>",
                 ephemeral=True,
             )
         else:

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -4,6 +4,8 @@ from discord.ext.commands import Bot
 from settings import get_settings
 from util import EmbedField, create_interaction_embed_context
 import logging
+import datetime
+import time
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -35,13 +37,14 @@ def create_bot_errors(bot: Bot) -> None:
     async def on_app_command_error(interaction: discord.Interaction, error):
         # Check if the error is due to a cooldown
         if isinstance(error, discord.app_commands.CommandOnCooldown):
-            hours_left = int(error.retry_after / 3600)
+            current_time = int(time.time())
+            remaining_time = int(error.retry_after)
             await interaction.response.send_message(
-                f"This command is on cooldown. Please try again in {hours_left} hour(s).",
+                f"This command is on cooldown. Time remaining: <t:{remaining_time + current_time}:R>",
                 ephemeral=True,
             )
         else:
-            logger.error(f"An unexpected error has occured {error}")
+            logger.error(f"An unexpected error has occurred {error}")
 
 
 @asynccontextmanager

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -4,7 +4,6 @@ from discord.ext.commands import Bot
 from settings import get_settings
 from util import EmbedField, create_interaction_embed_context
 import logging
-import datetime
 import time
 
 settings = get_settings()


### PR DESCRIPTION
Ticket: MOD-76

Current timestamp is retrieved along with the amount of seconds left on cooldown. The output adds both values together to get the unix timestamp for the end of the cooldown period. The same line of code formats the message into the markdown format discord allows showing how much time is remaining regardless of days, hours, or seconds.

Reference for unix timestamp discord capability: https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa