### PR TITLE
Add Strikes table and strikes user columns

### DIFF
--- a/postgres/create_tables.sql
+++ b/postgres/create_tables.sql
@@ -27,6 +27,11 @@ CREATE TABLE IF NOT EXISTS exiles (
 
 -- NOTE this should only be run once, then cleaned up into the create statements
 alter table users
+drop column IF EXISTS temporaryPoints,
+drop column IF EXISTS permanentPoints,
+drop column IF EXISTS lastInfractionTimestamp;
+
+alter table users
 add column temporaryPoints INT  not null default 0,
 add column permanentPoints INT  not null default 0,
 add column lastInfractionTimestamp TIMESTAMP;

--- a/postgres/create_tables.sql
+++ b/postgres/create_tables.sql
@@ -5,20 +5,14 @@ CREATE TABLE IF NOT EXISTS users (
 	discordUserID VARCHAR(20) NOT NULL,
 	discordGuildID VARCHAR(20) NOT NULL,
 	isMod BOOL NOT NULL,
+	-- temporaryPoints INT  not null default 0,
+	-- permanentPoints INT  not null default 0,
+	-- createTimestamp TIMESTAMP,
 	PRIMARY KEY(userID),
 	UNIQUE(discordUserID, discordGuildID)
 );
 
 CREATE INDEX IF NOT EXISTS index_discordUserID ON users(discordUserID);
-
-/*
-CREATE TABLE IF NOT EXISTS strikes (
-	strikeID INT GENERATED ALWAYS AS IDENTITY,
-	userID INT NOT NULL,
-	reason TEXT,
-	CONSTRAINT fk_user FOREIGN KEY(userID) REFERENCES users(userID)
-);
-*/
 
 CREATE TABLE IF NOT EXISTS exiles (
 	exileID INT GENERATED ALWAYS AS IDENTITY,
@@ -31,14 +25,25 @@ CREATE TABLE IF NOT EXISTS exiles (
 	CONSTRAINT fk_user FOREIGN KEY(userID) REFERENCES users(userID)
 );
 
+-- NOTE this should only be run once, then cleaned up into the create statements
+alter table users
+add column temporaryPoints INT  not null default 0,
+add column permanentPoints INT  not null default 0,
+add column lastInfractionTimestamp TIMESTAMP;
+DROP TABLE strikes;
+
+-- back to normal process
 CREATE TABLE IF NOT EXISTS strikes (
-	strikeID INT GENERATED ALWAYS AS IDENTITY,
+	StrikeID INT GENERATED ALWAYS AS IDENTITY,
 	userID INT NOT null,
+	severity INT NOT null,
 	reason TEXT,
-	createTimestamp TIMESTAMP,
-	PRIMARY KEY(strikeID), 
+	createdTimestamp TIMESTAMP,
+	createdBy VARCHAR(20) NOT NULL,
+	lastEditedTimestamp TIMESTAMP,
+	lastEditedBy VARCHAR(20) NOT NULL,
+	PRIMARY KEY(strikeID),
 	CONSTRAINT fk_user FOREIGN KEY(userID) REFERENCES users(userID)
 );
-
 
 COMMIT;


### PR DESCRIPTION
Since we are currently set up to do all DB changes at once, but strikes table is in a less-than-ideal spot (old changes mean bad columns etc) I am making this intermediary PR to remove the old strikes table, create from scratch the corrected strikes table, and update the users table to have the new columns it needs. I will make a follow up once this change is deployed to not have subsequent deployments cause issues

Ticket: MOD-87