### PR TITLE
Add chunked message helper function and condense automod notification message

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -73,11 +73,11 @@ def log_info_and_embed(embed: discord.Embed, logger, message: str):
 
 
 def _split_chunks(message_content: str, from_index: int, max_length: int = 2000):
-    # if message is shorter than max length
-    if (len(message_content) - from_index) < max_length:
-        return len(message_content)
+    max_index = from_index + max_length
 
-    max_index = max_length + from_index
+    # if remaining message is shorter than max chunk size
+    if len(message_content) < max_index:
+        return len(message_content)
 
     # split based on newline
     newline_index = message_content.rfind("\n", from_index, max_index)

--- a/src/util.py
+++ b/src/util.py
@@ -87,7 +87,6 @@ def _split_chunks(message_content: str, from_index: int, max_length: int = 2000)
     # split based on spaces
     space_index = message_content.rfind(" ", from_index, max_index)
     if space_index != -1:
-        print("a")
         return space_index + 1
 
     # else just send a chunk of 2000 characters

--- a/src/util.py
+++ b/src/util.py
@@ -72,8 +72,8 @@ def log_info_and_embed(embed: discord.Embed, logger, message: str):
     logger.info(message)
 
 
-def _split_chunks(message_content: str, from_index: int, max_length: int = 2000):
-    max_index = from_index + max_length
+def _split_chunks(message_content: str, from_index: int, max_chunk_length: int = 2000):
+    max_index = from_index + max_chunk_length
 
     # if remaining message is shorter than max chunk size
     if len(message_content) < max_index:
@@ -89,18 +89,22 @@ def _split_chunks(message_content: str, from_index: int, max_length: int = 2000)
     if space_index != -1:
         return space_index + 1
 
-    # else just send a chunk of 2000 characters
+    # else just send a chunk of max_chunk_length characters
     return max_index
 
 
-async def send_chunked_message(channel: discord.abc.GuildChannel, message_content: str):
+def chunk_message(message_content: str, max_chunk_length: int = 2000):
     from_index = 0
     to_index = 0
-
     while to_index < len(message_content):
-        to_index = _split_chunks(message_content, from_index)
-        await channel.send(message_content[from_index:to_index])
+        to_index = _split_chunks(message_content, from_index, max_chunk_length)
+        yield message_content[from_index:to_index]
         from_index = to_index
+
+
+async def send_chunked_message(channel: discord.abc.GuildChannel, message_content: str):
+    for chunk in chunk_message(message_content):
+        await channel.send(chunk)
 
 
 async def send_dm(member: discord.Member, messageContent: str):

--- a/src/util.py
+++ b/src/util.py
@@ -72,6 +72,38 @@ def log_info_and_embed(embed: discord.Embed, logger, message: str):
     logger.info(message)
 
 
+def _split_chunks(message_content: str, from_index: int, max_length: int = 2000):
+    # if message is shorter than max length
+    if (len(message_content) - from_index) < max_length:
+        return len(message_content)
+
+    max_index = max_length + from_index
+
+    # split based on newline
+    newline_index = message_content.rfind("\n", from_index, max_index)
+    if newline_index != -1:
+        return newline_index + 1
+
+    # split based on spaces
+    space_index = message_content.rfind(" ", from_index, max_index)
+    if space_index != -1:
+        print("a")
+        return space_index + 1
+
+    # else just send a chunk of 2000 characters
+    return max_index
+
+
+async def send_chunked_message(channel: discord.abc.GuildChannel, message_content: str):
+    from_index = 0
+    to_index = 0
+
+    while to_index < len(message_content):
+        to_index = _split_chunks(message_content, from_index)
+        await channel.send(message_content[from_index:to_index])
+        from_index = to_index
+
+
 async def send_dm(member: discord.Member, messageContent: str):
     channel = await member.create_dm()
     await channel.send(content=messageContent)

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -25,7 +25,7 @@ async def autodelete_threads(self):
     for channel_id, duration in settings.automod_inactivity.items():
         num_removed = 0
         num_errors = 0
-        user_list: list[int] = []
+        user_list: set[int] = set()
         try:
             channel = guild.get_channel(channel_id)
             if channel is None:

--- a/src/workers/forum_automod.py
+++ b/src/workers/forum_automod.py
@@ -3,7 +3,7 @@ import logging
 from settings import get_settings
 from .helper import create_automod_embed, automod_thread
 from discord.ext import tasks
-from util import create_interaction_embed_context
+from util import create_interaction_embed_context, send_chunked_message
 from discord.utils import snowflake_time
 
 settings = get_settings()
@@ -25,6 +25,7 @@ async def autodelete_threads(self):
     for channel_id, duration in settings.automod_inactivity.items():
         num_removed = 0
         num_errors = 0
+        user_list: list[int] = []
         try:
             channel = guild.get_channel(channel_id)
             if channel is None:
@@ -39,7 +40,7 @@ async def autodelete_threads(self):
                     duration,
                     num_removed,
                     num_errors,
-                    notifying_channel,
+                    user_list,
                 )
 
             for thread in channel.threads:
@@ -50,8 +51,13 @@ async def autodelete_threads(self):
                     duration,
                     num_removed,
                     num_errors,
-                    notifying_channel,
+                    user_list,
                 )
+
+            if num_removed > 0:
+                message = " ".join([f"<@{x}>" for x in user_list])
+                message += f"\nYour thread in <#{channel_id}> has been automatically deleted as {duration} days have passed without any activity or the original message has been deleted."
+                await send_chunked_message(notifying_channel, message)
 
             if num_removed > 0 or num_errors > 0:
                 logger.info(
@@ -65,6 +71,7 @@ async def autodelete_threads(self):
                     datetime.now(timezone.utc),
                 ):
                     pass
+
             else:
                 logger.info(
                     f"No threads were marked for deletion in channel {channel_id}."
@@ -75,7 +82,7 @@ async def autodelete_threads(self):
                 self.get_channel(settings.logging_channel_id),
                 user=self.user,
                 timestamp=datetime.now(timezone.utc),
-                description="Automod task failed to process channel <#{channel_id}>: {e}",
+                description=f"Automod task failed to process channel <#{channel_id}>: {e}",
             ):
                 pass
             continue

--- a/src/workers/helper.py
+++ b/src/workers/helper.py
@@ -45,7 +45,7 @@ async def automod_thread(
     duration: int,
     num_removed: int,
     num_errors: int,
-    notifying_channel: discord.TextChannel,
+    user_list: list[int],
 ):
     if thread.flags.pinned:
         # skip the for loop if the thread is pinned
@@ -73,12 +73,8 @@ async def automod_thread(
         logger.info(f"Thread {thread.id} has been deleted successfully")
         ret = num_removed + 1, num_errors
         if thread.owner is not None:
-            try:
-                await notifying_channel.send(
-                    f'{thread.owner.mention}, your post "{thread.name}" in <#{channel_id}> has been automatically deleted as {duration} days have passed without any activity or the original message has been deleted.'
-                )
-            except Exception as e:
-                raise UnableToNotify(e)
+            if thread.owner_id not in user_list:
+                user_list.append(thread.owner_id)
         else:
             raise UnableToNotify("User is not in the server")
         return ret
@@ -95,5 +91,5 @@ async def automod_thread(
         # NB: not really an error we're worried about since it's just notifying
         return num_removed + 1, num_errors
     except Exception as e:
-        logger.error(e)
+        logger.error(f"Unexpected error for thread {thread.id}: {e}")
         return num_removed, num_errors + 1

--- a/src/workers/helper.py
+++ b/src/workers/helper.py
@@ -45,7 +45,7 @@ async def automod_thread(
     duration: int,
     num_removed: int,
     num_errors: int,
-    user_list: list[int],
+    user_list: set[int],
 ):
     if thread.flags.pinned:
         # skip the for loop if the thread is pinned
@@ -73,8 +73,7 @@ async def automod_thread(
         logger.info(f"Thread {thread.id} has been deleted successfully")
         ret = num_removed + 1, num_errors
         if thread.owner is not None:
-            if thread.owner_id not in user_list:
-                user_list.append(thread.owner_id)
+            user_list.add(thread.owner_id)
         else:
             raise UnableToNotify("User is not in the server")
         return ret


### PR DESCRIPTION
Ticket: MOD-86
This PR condenses the automod notification message into a bulk ping. 

`send_chunked_message()` has been added to `util.py` that automatically splits messages that may exceed discord's character limit. `chunk_generator()` may also be used to extend functionality to embeds (3k characters max) if needed. I also fixed a small bug with error logging + made an error slightly more verbose