### PR TITLE
More robust role checks

### DIFF
--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -30,20 +30,35 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
         fields=fields,
     )
 
-
 def create_bot_errors(bot: Bot) -> None:
     @bot.tree.error
     async def on_app_command_error(interaction: discord.Interaction, error):
-        # Check if the error is due to a cooldown
+        # Handle CommandOnCooldown error
         if isinstance(error, discord.app_commands.CommandOnCooldown):
             remaining_time = int(error.retry_after) + int(time.time())
             await interaction.response.send_message(
-                f"This command is on cooldown. Time remaining: <t:{remaining_time}:R>",
+                f"This command is on cooldown. Time remaining: <t:{remaining_time}:R>.",
                 ephemeral=True,
             )
-        else:
-            logger.error(f"An unexpected error has occurred {error}")
 
+        # Handle CheckFailure error
+        elif isinstance(error, discord.app_commands.CheckFailure):
+            await interaction.response.send_message(
+                "You do not have the permissions to use this command.",
+                ephemeral=True,
+            )
+
+        # Handle other errors (default fallback)
+        else:
+            logger.error(f"An unexpected error has occurred: {error}")
+            try:
+                await interaction.response.send_message(
+                    "An unexpected error occurred. Please contact an admin.",
+                    ephemeral=True,
+                )
+            except discord.InteractionResponded:
+                # If interaction response has already been sent
+                logger.warning("Interaction already responded to.")
 
 @asynccontextmanager
 async def create_response_context(interaction: discord.Interaction, sendEphemeral=True):

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -38,14 +38,14 @@ def create_bot_errors(bot: Bot) -> None:
         if isinstance(error, discord.app_commands.CommandOnCooldown):
             remaining_time = int(error.retry_after) + int(time.time())
             await interaction.response.send_message(
-                f"This command is on cooldown. Time remaining: <t:{remaining_time}:R>.",
+                f"This command is on cooldown. Try again <t:{remaining_time}:R>.",
                 ephemeral=True,
             )
 
         # Handle CheckFailure error
         elif isinstance(error, discord.app_commands.CheckFailure):
             await interaction.response.send_message(
-                "You do not have the permissions to use this command.",
+                "You do not have the 'Mod' role to use this command.",
                 ephemeral=True,
             )
 

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -30,6 +30,7 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
         fields=fields,
     )
 
+
 def create_bot_errors(bot: Bot) -> None:
     @bot.tree.error
     async def on_app_command_error(interaction: discord.Interaction, error):
@@ -59,6 +60,7 @@ def create_bot_errors(bot: Bot) -> None:
             except discord.InteractionResponded:
                 # If interaction response has already been sent
                 logger.warning("Interaction already responded to.")
+
 
 @asynccontextmanager
 async def create_response_context(interaction: discord.Interaction, sendEphemeral=True):

--- a/src/enums.py
+++ b/src/enums.py
@@ -4,8 +4,6 @@ from enum import StrEnum, IntEnum
 class Role(StrEnum):
     EXILED = "Exiled"
     VERIFIED = "Verified"
-    ADMINISTRATION = "Administration"
-    MANAGEMENT = "Management"
     MOD = "Mod"
 
 

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -69,7 +69,7 @@ async def exile_user(
     try:
         await send_dm(
             user,
-            f"You are being exiled from NA Ultimate Raiding - FFXIV.\n**Reason:** {reason}\n**Time remaining:** <t:{timestamp}:R>",
+            f"You are being exiled from NA Ultimate Raiding - FFXIV.\n**Reason:** {reason}\nExile expires <t:{timestamp}:R>",
         )
     except Exception as e:
         log_info_and_embed(

--- a/src/util.py
+++ b/src/util.py
@@ -171,8 +171,4 @@ def calculate_time_delta(delta_string: Optional[str]) -> Optional[timedelta]:
 
 
 async def is_user_moderator(interaction: discord.Interaction):
-    return (
-        user_has_role(interaction.user, Role.ADMINISTRATION)
-        or user_has_role(interaction.user, Role.MANAGEMENT)
-        or user_has_role(interaction.user, Role.MOD)
-    )
+    return (user_has_role(interaction.user, Role.MOD))

--- a/src/util.py
+++ b/src/util.py
@@ -171,4 +171,4 @@ def calculate_time_delta(delta_string: Optional[str]) -> Optional[timedelta]:
 
 
 async def is_user_moderator(interaction: discord.Interaction):
-    return (user_has_role(interaction.user, Role.MOD))
+    return user_has_role(interaction.user, Role.MOD)


### PR DESCRIPTION
Ticket: MOD-28

- Removes all unnecessary is_user_moderator roles and checks only if the user has "Mod" role.
- Better error handeling if the role is missing in is_user_moderator check
- `ERROR:commands.helper:An unexpected error has occurred The check functions for command` will no longer be reported if check is failed, gracefully catching this error