### PR TITLE
Fix ban command so staff cannot ban each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ To run a dockerized version of our postgres database locally, run `make database
 When you first are setting up the application, copy the file titled `.env_example` to be `.env`, and configure the missing enviornment variables. To add the bot account to your server, you can follow the [discord.py instructions](https://discordpy.readthedocs.io/en/stable/discord.html). The server that you use for development also will need to have a channel where the bot will output logging messages, and will need to have the following roles set up
 * Exiled
 * Verified
-* Administration
-* Management
+* Mod
 
-In addition, you will need to give yourself either the `Administration` or `Management` role in order to properly run all commands.
+In addition, you will need to give yourself the `Mod` role in order to properly run all moderation commands.
 
 ### Black Formatter
 Files in this repo will be run through the [Black Formatter](https://black.readthedocs.io/en/stable/). To minimize merge conflicts, it is recommended to run this formatter on your code before submitting. Most IDEs will have an extension for black, and it is recommended to use those

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -15,46 +15,42 @@ def create_ban_commands(bot: Bot) -> None:
     @discord.app_commands.describe(
         user="User being banned",
         reason="Reason for ban",
-        delete_messages="Type 'Yes' to delete messages or 'No' to keep them (default: 'No')",
+        delete_messages="Whether messages from the banned user should be deleted or not",
     )
     async def ban(
         interaction: discord.Interaction,
         user: discord.Member,
         reason: str,
-        delete_messages: str = "No",  # Default to 'No' for no message deletion
+        delete_messages: bool = False,  # Default to false for no message deletion as we typically don't want to delete messages.
     ):
         """Ban the specified user."""
-        # Normalize and validate the input
-        delete_messages = delete_messages.strip().capitalize()  # Handle capitalization
-        if delete_messages not in ["Yes", "No"]:
-            await interaction.response.send_message(
-                "Invalid value for 'delete_messages'. Please enter 'Yes' to delete messages or 'No' to keep them.",
-                ephemeral=True,
-            )
-            return
-
-        # Convert delete_messages to a boolean for ban logic
-        delete_messages_flag = delete_messages == "Yes"
-
         async with create_response_context(interaction) as response_message:
-            (is_banned, result_description) = await ban_user(
-                interaction.user, user, reason, delete_messages_flag
-            )
-
-            if is_banned:  # Ban succeeded
-                async with create_logging_embed(
-                    interaction,
-                    user=user,
-                    reason=reason,
-                    result=result_description,
-                    delete_messages_flag=delete_messages_flag,  # Pass as "Yes" or "No"
-                ) as logging_embed:
-                    response_message.set_string(result_description)
-            else:  # Ban failed
-                async with create_logging_embed(
-                    interaction, user=user, reason=reason, error=result_description
-                ) as logging_embed:
-                    response_message.set_string(result_description)
+            ban_success, error = await ban_user(user, reason, delete_messages)
+            # Ensure invoking_member has a higher role position than the target user.
+            if user.top_role >= interaction.user.top_role:
+                response_message.set_string(
+                    f"Unable to ban {user.mention}: You cannot ban a user with an equal or higher role than yourself."
+                )
+                return
+            async with create_logging_embed(
+                interaction,
+                user=user,
+                reason=reason,
+                delete_messages=delete_messages,
+            ) as logging_embed:
+                if ban_success:
+                    success_str = f"Successfully banned {user.mention}."
+                    logging_embed.add_field(
+                        name="Result", value=success_str, inline=False
+                    )
+                    response_message.set_string(success_str)
+                    if error:
+                        logging_embed.add_field(
+                            name="DM Status", value=error, inline=False
+                        )
+                else:
+                    logging_embed.add_field(name="Error", value=error, inline=False)
+                    response_message.set_string(error)
 
     @bot.tree.context_menu(name="Ban User")
     @discord.app_commands.check(is_user_moderator)

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -37,7 +37,7 @@ def create_ban_commands(bot: Bot) -> None:
         delete_messages_flag = delete_messages == "Yes"
 
         async with create_response_context(interaction) as response_message:
-            (is_banned, is_dm_sent, result_description) = await ban_user(
+            (is_banned, result_description) = await ban_user(
                 interaction.user, user, reason, delete_messages_flag
             )
 

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -41,13 +41,12 @@ def create_ban_commands(bot: Bot) -> None:
 
             if is_banned:  # Ban succeeded
                 async with create_logging_embed(
-                    interaction, user=user, reason=reason, result=result_description
+                    interaction,
+                    user=user,
+                    reason=reason,
+                    result=result_description,
+                    delete_messages_flag=delete_messages_flag,
                 ) as logging_embed:
-                    logging_embed.add_field(
-                        name="Messages Deleted",
-                        value="Yes" if delete_messages_flag else "No",
-                        inline=False,
-                    )
                     response_message.set_string(result_description)
             else:  # Ban failed
                 async with create_logging_embed(

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -15,25 +15,27 @@ def create_ban_commands(bot: Bot) -> None:
     @discord.app_commands.describe(
         user="User being banned",
         reason="Reason for ban",
-        delete_messages="Type 'Y' to delete messages or 'N' to keep them (default: 'N')",
+        delete_messages="Type 'Yes' to delete messages or 'No' to keep them (default: 'No')",
     )
     async def ban(
         interaction: discord.Interaction,
         user: discord.Member,
         reason: str,
-        delete_messages: str = "N",  # Default to 'N' for no message deletion
+        delete_messages: str = "No",  # Default to 'No' for no message deletion
     ):
         """Ban the specified user."""
         # Normalize and validate the input
-        delete_messages = delete_messages.strip().upper()
-        if delete_messages not in ["Y", "N"]:
+        delete_messages = delete_messages.strip().capitalize()  # Handle capitalization
+        if delete_messages not in ["Yes", "No"]:
             await interaction.response.send_message(
-                "Invalid value for 'delete_messages'. Please enter 'Y' to delete messages or 'N' to keep them.",
+                "Invalid value for 'delete_messages'. Please enter 'Yes' to delete messages or 'No' to keep them.",
                 ephemeral=True,
             )
             return
 
-        delete_messages_flag = delete_messages == "Y"  # Convert to boolean
+        # Convert delete_messages to a boolean for ban logic
+        delete_messages_flag = delete_messages == "Yes"
+
         async with create_response_context(interaction) as response_message:
             (is_banned, is_dm_sent, result_description) = await ban_user(
                 interaction.user, user, reason, delete_messages_flag
@@ -45,7 +47,7 @@ def create_ban_commands(bot: Bot) -> None:
                     user=user,
                     reason=reason,
                     result=result_description,
-                    delete_messages_flag=delete_messages_flag,
+                    delete_messages_flag=delete_messages_flag,  # Pass as "Yes" or "No"
                 ) as logging_embed:
                     response_message.set_string(result_description)
             else:  # Ban failed

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -15,16 +15,18 @@ def create_ban_commands(bot: Bot) -> None:
     @discord.app_commands.describe(
         user="User being banned",
         reason="Reason for ban",
+        delete_messages="Whether to delete the user's messages (default: False)",
     )
     async def ban(
         interaction: discord.Interaction,
         user: discord.Member,
         reason: str,
+        delete_messages: bool = False,  # Default to not deleting messages
     ):
         """Ban the specified user."""
         async with create_response_context(interaction) as response_message:
             (is_banned, is_dm_sent, result_description) = await ban_user(
-                interaction.user, user, reason
+                interaction.user, user, reason, delete_messages
             )
 
             if is_banned:  # ban succeeded

--- a/src/commands/ban_commands.py
+++ b/src/commands/ban_commands.py
@@ -23,7 +23,9 @@ def create_ban_commands(bot: Bot) -> None:
     ):
         """Ban the specified user."""
         async with create_response_context(interaction) as response_message:
-            (is_banned, is_dm_sent, result_description) = await ban_user(user, reason)
+            (is_banned, is_dm_sent, result_description) = await ban_user(
+                interaction.user, user, reason
+            )
 
             if is_banned:  # ban succeeded
                 if not is_dm_sent:  # dm failed

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -21,7 +21,10 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
                 case discord.ChannelType:
                     fields.append(EmbedField(key.title(), f"<#{value}>"))
                 case _:
-                    fields.append(EmbedField(key.title(), value))
+                    if "delete_messages_flag" in key:
+                        fields.append(EmbedField("Messages Deleted", value))
+                    else:
+                        fields.append(EmbedField(key.title(), value))
 
     return create_interaction_embed_context(
         interaction.guild.get_channel(settings.logging_channel_id),

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -20,7 +20,7 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
                     fields.append(EmbedField(key.title(), f"<@{value.id}>"))
                 case discord.ChannelType:
                     fields.append(EmbedField(key.title(), f"<#{value}>"))
-                case _:  # Irrefutable pattern for all other types
+                case _:
                     fields.append(EmbedField(key.title(), value))
 
     return create_interaction_embed_context(

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 import discord
+import builtins
 from discord.ext.commands import Bot
 from settings import get_settings
 from util import EmbedField, create_interaction_embed_context
@@ -15,16 +16,14 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
     # Dynamically add kwargs to fields
     if kwargs is not None:
         for key, value in kwargs.items():
+            key = key.replace("_", " ")
             match (type(value)):
                 case discord.Member:
                     fields.append(EmbedField(key.title(), f"<@{value.id}>"))
                 case discord.ChannelType:
                     fields.append(EmbedField(key.title(), f"<#{value}>"))
-                case _:
-                    if "delete_messages_flag" in key:
-                        fields.append(EmbedField("Messages Deleted", value))
-                    else:
-                        fields.append(EmbedField(key.title(), value))
+                case builtins.bool:
+                    fields.append(EmbedField(key.title(), f"{value}"))
 
     return create_interaction_embed_context(
         interaction.guild.get_channel(settings.logging_channel_id),

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -10,10 +10,9 @@ settings = get_settings()
 logger = logging.getLogger(__name__)
 
 
-def create_logging_embed(
-    interaction: discord.Interaction, delete_messages_flag=None, **kwargs
-):
+def create_logging_embed(interaction: discord.Interaction, **kwargs):
     fields = [EmbedField("Action", f"/{interaction.command.name}")]
+    # Dynamically add kwargs to fields
     if kwargs is not None:
         for key, value in kwargs.items():
             match (type(value)):
@@ -21,17 +20,8 @@ def create_logging_embed(
                     fields.append(EmbedField(key.title(), f"<@{value.id}>"))
                 case discord.ChannelType:
                     fields.append(EmbedField(key.title(), f"<#{value}>"))
-                case _:
+                case _:  # Irrefutable pattern for all other types
                     fields.append(EmbedField(key.title(), value))
-
-    # Add "Messages Deleted" field if delete_messages_flag is provided
-    if delete_messages_flag is not None:
-        fields.append(
-            EmbedField(
-                "Messages Deleted",
-                "Yes" if delete_messages_flag else "No",
-            )
-        )
 
     return create_interaction_embed_context(
         interaction.guild.get_channel(settings.logging_channel_id),

--- a/src/commands/helper.py
+++ b/src/commands/helper.py
@@ -10,7 +10,9 @@ settings = get_settings()
 logger = logging.getLogger(__name__)
 
 
-def create_logging_embed(interaction: discord.Interaction, **kwargs):
+def create_logging_embed(
+    interaction: discord.Interaction, delete_messages_flag=None, **kwargs
+):
     fields = [EmbedField("Action", f"/{interaction.command.name}")]
     if kwargs is not None:
         for key, value in kwargs.items():
@@ -21,6 +23,15 @@ def create_logging_embed(interaction: discord.Interaction, **kwargs):
                     fields.append(EmbedField(key.title(), f"<#{value}>"))
                 case _:
                     fields.append(EmbedField(key.title(), value))
+
+    # Add "Messages Deleted" field if delete_messages_flag is provided
+    if delete_messages_flag is not None:
+        fields.append(
+            EmbedField(
+                "Messages Deleted",
+                "Yes" if delete_messages_flag else "No",
+            )
+        )
 
     return create_interaction_embed_context(
         interaction.guild.get_channel(settings.logging_channel_id),

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -14,7 +14,7 @@ async def ban_user(
     user: discord.Member,
     reason: str,
     delete_messages_flag: bool,
-) -> Optional[Tuple[bool, bool, str]]:
+) -> Optional[Tuple[bool, str]]:
     """Executes ban of user.
 
     Args:
@@ -26,12 +26,10 @@ async def ban_user(
     Returns:
         Optional[Tuple[bool, bool, str]]: Result of the ban operation. Tuple contains:
             - bool: True if ban was successful, False otherwise.
-            - bool: True if DM was successfully sent, False otherwise.
             - str: Description of the result of the ban operation
     """
     if len(reason) >= 512:
         return (
-            False,
             False,
             f"Unable to ban {user.mention}: reason is too long (above 512 characters). Please shorten the ban reason.",
         )
@@ -39,7 +37,6 @@ async def ban_user(
     # Ensure invoking_member has a higher role position than the target user.
     if user.top_role >= invoking_member.top_role:
         return (
-            False,
             False,
             f"Unable to ban {user.mention}: You cannot ban a user with an equal or higher role than yourself.",
         )
@@ -58,7 +55,6 @@ async def ban_user(
             f"If you believe this ban was issued in error you can reach out to the Moderation Team. Otherwise, you may appeal this ban starting on <t:{appeal_deadline}:F>.\n\n"
             "Please note that any further attempts to rejoin the server will be met with a permanent ban.\n\n",
         )
-        dm_state = True
     except Exception as e:
         logger.error(f"Failed to send DM to {user.mention}: {e}")
 
@@ -70,11 +66,10 @@ async def ban_user(
         delete_seconds = 604800 if delete_messages_flag else 0
         await user.ban(reason=reason, delete_message_seconds=delete_seconds)
         logger.info(f"Successfully banned {user.mention}")
-        return (True, dm_state, f"Successfully banned {user.mention}.")
+        return (True, f"Successfully banned {user.mention}.")
     except Exception as e:
         logger.error(f"Failed to ban {user.mention}: {e}")
         return (
             False,
-            dm_state,
             f"Failed to ban {user.mention}. Please try again or use Discord's built-in tools.",
         )

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -15,7 +15,6 @@ async def ban_user(
     """Executes ban of user.
 
      Args:
-         invoking_member (discord.Member): The moderator initiating the ban.
          user (discord.Member): The user being banned.
          reason (str): Reason for the ban.
          delete_messages_flag (bool): Whether to delete the user's messages.
@@ -33,7 +32,7 @@ async def ban_user(
     # Calculate the timestamp for 30 days from now
     appeal_deadline = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
 
-    dm_failed = None
+    dm_failed_message = None
     try:
         await send_dm(
             user,
@@ -47,7 +46,7 @@ async def ban_user(
     except Exception as e:
         err = f"Failed to send DM to {user.mention}: {e}"
         logger.error(err)
-        dm_failed = err
+        dm_failed_message = err
 
     try:
         # 604800 seconds is the maximum value for delete_message_seconds, and is equivalent to 7 days.
@@ -55,7 +54,7 @@ async def ban_user(
         await user.ban(reason=reason, delete_message_seconds=delete_seconds)
         logger.info(f"Successfully banned {user.mention}")
 
-        return True, dm_failed
+        return True, dm_failed_message
     except Exception as e:
         logger.error(f"Failed to ban {user.mention}: {e}")
         return (

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -24,9 +24,9 @@ async def ban_user(
         delete_messages_flag (bool): Whether to delete the user's messages.
 
     Returns:
-        Optional[Tuple[bool, bool, str]]: Result of the ban operation. Tuple contains:
-            - bool: True if ban was successful, False otherwise.
-            - str: Description of the result of the ban operation
+        Optional[Tuple[bool, str]]: Result of the ban operation. Tuple contains:
+            - delete_messages_flag: True if ban was successful, False otherwise.
+            - reason: Description of the result of the ban operation
     """
     if len(reason) >= 512:
         return (
@@ -44,7 +44,6 @@ async def ban_user(
     # Calculate the timestamp for 30 days from now
     appeal_deadline = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
 
-    dm_state = False
     try:
         await send_dm(
             user,

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -10,23 +10,19 @@ logger = logging.getLogger(__name__)
 
 
 async def ban_user(
-    invoking_member: discord.Member,
-    user: discord.Member,
-    reason: str,
-    delete_messages_flag: bool,
+    user: discord.Member, reason: str, delete_messages: bool
 ) -> Optional[Tuple[bool, str]]:
     """Executes ban of user.
 
-    Args:
-        invoking_member (discord.Member): The moderator initiating the ban.
-        user (discord.Member): The user being banned.
-        reason (str): Reason for the ban.
-        delete_messages_flag (bool): Whether to delete the user's messages.
+     Args:
+         invoking_member (discord.Member): The moderator initiating the ban.
+         user (discord.Member): The user being banned.
+         reason (str): Reason for the ban.
+         delete_messages_flag (bool): Whether to delete the user's messages.
 
     Returns:
-        Optional[Tuple[bool, str]]: Result of the ban operation. Tuple contains:
-            - delete_messages_flag: True if ban was successful, False otherwise.
-            - reason: Description of the result of the ban operation
+         bool: status of the ban
+         str: any errors that occurred
     """
     if len(reason) >= 512:
         return (
@@ -34,16 +30,10 @@ async def ban_user(
             f"Unable to ban {user.mention}: reason is too long (above 512 characters). Please shorten the ban reason.",
         )
 
-    # Ensure invoking_member has a higher role position than the target user.
-    if user.top_role >= invoking_member.top_role:
-        return (
-            False,
-            f"Unable to ban {user.mention}: You cannot ban a user with an equal or higher role than yourself.",
-        )
-
     # Calculate the timestamp for 30 days from now
     appeal_deadline = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
 
+    dm_failed = None
     try:
         await send_dm(
             user,
@@ -55,17 +45,17 @@ async def ban_user(
             "Please note that any further attempts to rejoin the server will be met with a permanent ban.\n\n",
         )
     except Exception as e:
-        logger.error(f"Failed to send DM to {user.mention}: {e}")
+        err = f"Failed to send DM to {user.mention}: {e}"
+        logger.error(err)
+        dm_failed = err
 
     try:
-        # We typically do NOT want to delete messages, as we want to preserve evidence.
-        # However, we may want to delete messages in cases where the user has posted inappropriate content or spam.
-        # Delete messages only if delete_messages is True
         # 604800 seconds is the maximum value for delete_message_seconds, and is equivalent to 7 days.
-        delete_seconds = 604800 if delete_messages_flag else 0
+        delete_seconds = 604800 if delete_messages else 0
         await user.ban(reason=reason, delete_message_seconds=delete_seconds)
         logger.info(f"Successfully banned {user.mention}")
-        return (True, f"Successfully banned {user.mention}.")
+
+        return True, dm_failed
     except Exception as e:
         logger.error(f"Failed to ban {user.mention}: {e}")
         return (

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -56,8 +56,9 @@ async def ban_user(
 
     try:
         # Delete messages only if delete_messages is True
-        delete_days = 7 if delete_messages else 0
-        await user.ban(reason=reason, delete_message_days=delete_days)
+        # 604800 seconds is the maximum value for delete_message_seconds, and is equivalent to 7 days.
+        delete_seconds = 604800 if delete_messages else 0
+        await user.ban(reason=reason, delete_message_seconds=delete_seconds)
         logger.info(f"Successfully banned {user.mention}")
         return (True, dm_state, f"Successfully banned {user.mention}.")
     except Exception as e:

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -3,6 +3,7 @@ import logging
 from typing import Optional, Tuple
 from util import log_info_and_embed, send_dm
 from settings import get_settings
+from datetime import datetime, timedelta, timezone
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -43,12 +44,19 @@ async def ban_user(
             f"Unable to ban {user.mention}: You cannot ban a user with an equal or higher role than yourself.",
         )
 
+    # Calculate the timestamp for 30 days from now
+    appeal_deadline = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+
     dm_state = False
     try:
         await send_dm(
             user,
-            f"You are being banned from NA Ultimate Raiding - FFXIV for the following reason:\n> {reason}\n"
-            "You may appeal this ban by contacting the moderators in 30 days.",
+            f"Hello {user.display_name},\n\n"
+            "You are being informed that you have been **banned** from **NA Ultimate Raiding - FFXIV**.\n\n"
+            "**Reason for the ban:**\n"
+            f"> {reason}\n\n"
+            f"If you believe this ban was issued in error you can reach out to the Moderation Team. Otherwise, you may appeal this ban starting on <t:{appeal_deadline}:F>.\n\n"
+            "Please note that any further attempts to rejoin the server will be met with a permanent ban.\n\n",
         )
         dm_state = True
     except Exception as e:

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -9,7 +9,10 @@ logger = logging.getLogger(__name__)
 
 
 async def ban_user(
-    invoking_member: discord.Member, user: discord.Member, reason: str
+    invoking_member: discord.Member,
+    user: discord.Member,
+    reason: str,
+    delete_messages: bool,
 ) -> Optional[Tuple[bool, bool, str]]:
     """Executes ban of user.
 
@@ -17,6 +20,7 @@ async def ban_user(
         invoking_member (discord.Member): The moderator initiating the ban.
         user (discord.Member): The user being banned.
         reason (str): Reason for the ban.
+        delete_messages (bool): Whether to delete the user's messages.
 
     Returns:
         Optional[Tuple[bool, bool, str]]: Result of the ban operation. Tuple contains:
@@ -43,7 +47,7 @@ async def ban_user(
     try:
         await send_dm(
             user,
-            f"You are being banned from the server for the following reason:\n> {reason}\n"
+            f"You are being banned from NA Ultimate Raiding - FFXIV for the following reason:\n> {reason}\n"
             "You may appeal this ban by contacting the moderators in 30 days.",
         )
         dm_state = True
@@ -51,7 +55,9 @@ async def ban_user(
         logger.error(f"Failed to send DM to {user.mention}: {e}")
 
     try:
-        await user.ban(reason=reason)
+        # Delete messages only if delete_messages is True
+        delete_days = 7 if delete_messages else 0
+        await user.ban(reason=reason, delete_message_days=delete_days)
         logger.info(f"Successfully banned {user.mention}")
         return (True, dm_state, f"Successfully banned {user.mention}.")
     except Exception as e:

--- a/src/services/ban_service.py
+++ b/src/services/ban_service.py
@@ -12,7 +12,7 @@ async def ban_user(
     invoking_member: discord.Member,
     user: discord.Member,
     reason: str,
-    delete_messages: bool,
+    delete_messages_flag: bool,
 ) -> Optional[Tuple[bool, bool, str]]:
     """Executes ban of user.
 
@@ -20,7 +20,7 @@ async def ban_user(
         invoking_member (discord.Member): The moderator initiating the ban.
         user (discord.Member): The user being banned.
         reason (str): Reason for the ban.
-        delete_messages (bool): Whether to delete the user's messages.
+        delete_messages_flag (bool): Whether to delete the user's messages.
 
     Returns:
         Optional[Tuple[bool, bool, str]]: Result of the ban operation. Tuple contains:
@@ -55,9 +55,11 @@ async def ban_user(
         logger.error(f"Failed to send DM to {user.mention}: {e}")
 
     try:
+        # We typically do NOT want to delete messages, as we want to preserve evidence.
+        # However, we may want to delete messages in cases where the user has posted inappropriate content or spam.
         # Delete messages only if delete_messages is True
         # 604800 seconds is the maximum value for delete_message_seconds, and is equivalent to 7 days.
-        delete_seconds = 604800 if delete_messages else 0
+        delete_seconds = 604800 if delete_messages_flag else 0
         await user.ban(reason=reason, delete_message_seconds=delete_seconds)
         logger.info(f"Successfully banned {user.mention}")
         return (True, dm_state, f"Successfully banned {user.mention}.")

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,2 +1,3 @@
+# TODO: [MOD-92] Decomm Modals
 from .ban_modal import *
 from .exile_modal import *

--- a/src/ui/ban_modal.py
+++ b/src/ui/ban_modal.py
@@ -1,3 +1,4 @@
+# TODO: [MOD-92] Decomm Modals
 import discord
 from services.ban_service import ban_user
 from .helper import create_modal_embed
@@ -18,26 +19,7 @@ class BanModal(discord.ui.Modal):
         required=True,
     )
 
-    delete_messages = discord.ui.TextInput(
-        label="Delete Messages? (Y/N)",
-        style=discord.TextStyle.short,
-        placeholder='Type "Y" for Yes or "N" for No',
-        max_length=1,
-        required=True,
-    )
-
     async def on_submit(self, interaction: discord.Interaction):
-        delete_messages_value = (
-            self.delete_messages.value.strip().upper()
-        )  # Normalize input
-        if delete_messages_value not in ["Y", "N"]:
-            await interaction.response.send_message(
-                "Invalid input for 'Delete Messages'. Please enter 'Y' or 'N'.",
-                ephemeral=True,
-            )
-            return
-
-        delete_messages_flag = delete_messages_value == "Y"  # Convert to boolean
         async with create_response_context(interaction) as response_message:
             async with create_modal_embed(
                 interaction,
@@ -45,14 +27,6 @@ class BanModal(discord.ui.Modal):
                 user=self.user,
                 reason=self.reason.value,
             ) as logging_embed:
-                result = await ban_user(
-                    interaction.user, self.user, self.reason.value, delete_messages_flag
-                )
+                await ban_user(logging_embed, self.user, self.reason.value)
 
-                if result[0]:  # Ban was successful
-                    response_message.set_string(
-                        f"Successfully banned {self.user.mention}."
-                    )
-                else:  # Ban failed
-                    response_message.set_string(result[2])
-                    logging_embed.add_field(name="Error", value=result[2], inline=False)
+                response_message.set_string(f"Successfully banned {self.user.mention}")

--- a/src/ui/ban_modal.py
+++ b/src/ui/ban_modal.py
@@ -19,17 +19,25 @@ class BanModal(discord.ui.Modal):
     )
 
     delete_messages = discord.ui.TextInput(
-        label="Delete Messages?",
+        label="Delete Messages? (Y/N)",
         style=discord.TextStyle.short,
-        placeholder='Type "Yes" to delete messages or "No" to keep them',
-        max_length=3,
+        placeholder='Type "Y" for Yes or "N" for No',
+        max_length=1,
         required=True,
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        delete_messages_flag = (
-            self.delete_messages.value.strip().lower() == "yes"
-        )  # Convert input to boolean
+        delete_messages_value = (
+            self.delete_messages.value.strip().upper()
+        )  # Normalize input
+        if delete_messages_value not in ["Y", "N"]:
+            await interaction.response.send_message(
+                "Invalid input for 'Delete Messages'. Please enter 'Y' or 'N'.",
+                ephemeral=True,
+            )
+            return
+
+        delete_messages_flag = delete_messages_value == "Y"  # Convert to boolean
         async with create_response_context(interaction) as response_message:
             async with create_modal_embed(
                 interaction,

--- a/src/ui/exile_modal.py
+++ b/src/ui/exile_modal.py
@@ -1,3 +1,4 @@
+# TODO: [MOD-92] Decomm Modals
 import discord
 from services.exile_service import exile_user
 from util import calculate_time_delta

--- a/src/ui/helper.py
+++ b/src/ui/helper.py
@@ -1,3 +1,4 @@
+# TODO: [MOD-92] Decomm Modals
 import discord
 from settings import get_settings
 from util import EmbedField, create_interaction_embed_context


### PR DESCRIPTION
Ticket: MOD-89

- Users cannot ban someone with equal or higher role their current role via moddingway.
- User is given the error when trying to ban someone of equal or higher rank: Unable to ban {user.mention}: You cannot ban a user with an equal or higher role than yourself
- Fixed README to be up to date with current scope of role requirements