### PR TITLE
Take out excessive user in db check for unexile

### DIFF
--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -108,15 +108,13 @@ async def unexile_user(
     # update exile record
     db_user = users_database.get_user(user.id)
     if db_user is None:
+        error_message = "User does not exist in database, does not have any exiles, no action will be taken"
         log_info_and_embed(
             logging_embed,
             logger,
-            f"User not found in database, creating new record",
+            error_message,
         )
-        db_user_id = users_database.add_user(user.id)
-        log_info_and_embed(logging_embed, logger, f"User record created in database")
-
-        db_user = User(db_user_id, user.id, None, None)
+        return error_message;
 
     exile = exiles_database.get_user_active_exile(db_user.user_id)
 

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -108,7 +108,7 @@ async def unexile_user(
     # update exile record
     db_user = users_database.get_user(user.id)
     if db_user is None:
-        error_message = "User does not exist in database, does not have any exiles, no action will be taken"
+        error_message = "User does not have any exiles, no action will be taken"
         log_info_and_embed(
             logging_embed,
             logger,

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -114,7 +114,7 @@ async def unexile_user(
             logger,
             error_message,
         )
-        return error_message;
+        return error_message
 
     exile = exiles_database.get_user_active_exile(db_user.user_id)
 


### PR DESCRIPTION
Ticket: MOD-81
Bot returns an error if target trying to get unexiled does not exist in database.
Note: I am not sure if there is a condition where user exists in users table but not in the exiles so I could not get the next if statement to trigger. Please review.