### PR TITLE
Stop exile command from being used on Mods and Admins

### DIFF
--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -67,7 +67,7 @@ def create_exile_commands(bot: Bot) -> None:
                 expiration=end_timestamp,
             ) as logging_embed:
                 error_message = await exile_user(
-                    logging_embed, user, exile_duration, reason
+                    logging_embed, user, exile_duration, reason, interaction
                 )
 
                 response_message.set_string(
@@ -104,7 +104,7 @@ def create_exile_commands(bot: Bot) -> None:
                 reason = "roulette"
                 exile_duration = calculate_time_delta(duration_string)
                 error_message = await exile_user(
-                    logging_embed, interaction.user, exile_duration, reason
+                    logging_embed, interaction.user, exile_duration, reason, interaction
                 )
 
                 if error_message:

--- a/src/enums.py
+++ b/src/enums.py
@@ -5,6 +5,7 @@ class Role(StrEnum):
     EXILED = "Exiled"
     VERIFIED = "Verified"
     MOD = "Mod"
+    ADMING = "Admin"
 
 
 class ExileStatus(IntEnum):

--- a/src/enums.py
+++ b/src/enums.py
@@ -5,7 +5,6 @@ class Role(StrEnum):
     EXILED = "Exiled"
     VERIFIED = "Verified"
     MOD = "Mod"
-    ADMIN = "Admin"
 
 
 class ExileStatus(IntEnum):

--- a/src/enums.py
+++ b/src/enums.py
@@ -5,7 +5,7 @@ class Role(StrEnum):
     EXILED = "Exiled"
     VERIFIED = "Verified"
     MOD = "Mod"
-    ADMING = "Admin"
+    ADMIN = "Admin"
 
 
 class ExileStatus(IntEnum):

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -102,7 +102,15 @@ async def unexile_user(
             error_message,
         )
         return error_message
-
+    if user_has_role(user, Role.MOD) or user_has_role(user, Role.ADMIN):
+        error_message = "User is a mod or an admin, no action will be taken"
+        log_info_and_add_field(
+            logging_embed,
+            logger,
+            "Error",
+            error_message,
+        )
+        return error_message
     # unexile user
     await add_and_remove_role(user, Role.VERIFIED, Role.EXILED)
 

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -6,6 +6,7 @@ from util import (
     add_and_remove_role,
     send_dm,
     user_has_role,
+    is_user_moderator,
 )
 from enums import Role, ExileStatus
 from database import users_database, exiles_database
@@ -33,8 +34,8 @@ async def exile_user(
             error_message,
         )
         return error_message
-    if user_has_role(user, Role.MOD) or user_has_role(user, Role.ADMIN):
-        error_message = "User is a mod or an admin, no action will be taken"
+    if user_has_role(user, Role.MOD):
+        error_message = "User is a mod, no action will be taken"
         log_info_and_add_field(
             logging_embed,
             logger,

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -33,7 +33,15 @@ async def exile_user(
             error_message,
         )
         return error_message
-
+    if user_has_role(user, Role.MOD) or user_has_role(user, Role.ADMIN):
+        error_message = "User is a mod or an admin, no action will be taken"
+        log_info_and_add_field(
+            logging_embed,
+            logger,
+            "Error",
+            error_message,
+        )
+        return error_message
     # look up user in DB
     db_user = users_database.get_user(user.id)
     if db_user is None:
@@ -102,15 +110,7 @@ async def unexile_user(
             error_message,
         )
         return error_message
-    if user_has_role(user, Role.MOD) or user_has_role(user, Role.ADMIN):
-        error_message = "User is a mod or an admin, no action will be taken"
-        log_info_and_add_field(
-            logging_embed,
-            logger,
-            "Error",
-            error_message,
-        )
-        return error_message
+
     # unexile user
     await add_and_remove_role(user, Role.VERIFIED, Role.EXILED)
 

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -23,6 +23,7 @@ async def exile_user(
     user: discord.Member,
     duration: datetime.timedelta,
     reason: str,
+    interaction: discord.Interaction,
 ) -> Optional[str]:
     if not user_has_role(user, Role.VERIFIED):
         error_message = "User is not currently verified, no action will be taken"
@@ -33,8 +34,8 @@ async def exile_user(
             error_message,
         )
         return error_message
-    if user_has_role(user, Role.MOD):
-        error_message = "User is a mod, no action will be taken"
+    if user.top_role >= interaction.user.top_role:
+        error_message = f"Unable to exile {user.mention}: You cannot exile a user with an equal or higher role than yourself."
         log_info_and_add_field(
             logging_embed,
             logger,

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -6,7 +6,6 @@ from util import (
     add_and_remove_role,
     send_dm,
     user_has_role,
-    is_user_moderator,
 )
 from enums import Role, ExileStatus
 from database import users_database, exiles_database


### PR DESCRIPTION
Ticket: MOD-90
/exile and /roulette(when succesfull) now errors out when they target a mod

