### PR TITLE
Stop the view_exiles command from logging an embed UNLESS it fails

### DIFF
--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -127,10 +127,15 @@ def create_exile_commands(bot: Bot) -> None:
         """View logged exiles of a user."""
 
         async with create_response_context(interaction) as response_message:
-            async with create_logging_embed(interaction, user=user) as logging_embed:
-                msg = await get_user_exiles(logging_embed, user)
-
+            try:
+                msg = await get_user_exiles(user)
                 response_message.set_string(msg)
+            except Exception as e:
+                logger.error(f"Error in get_user_exiles: {str(e)}")
+                async with create_logging_embed(interaction, user=user, error=str(e)):
+                    response_message.set_string(
+                        "An error occurred while fetching user exiles."
+                    )
 
     @bot.tree.command()
     @discord.app_commands.check(is_user_moderator)

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -150,7 +150,7 @@ async def unexile_user(
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-async def get_user_exiles(logging_embed: discord.Embed, user: discord.User) -> str:
+async def get_user_exiles(user: discord.User) -> str:
     db_user = users_database.get_user(user.id)
     if db_user is None:
         return "User not found in database"


### PR DESCRIPTION
Ticket:MOD-95
get_user_exiles now doesnt send an embed to log channel unless there is error
removed embed param from the function
