### PR TITLE
add tests for simple util methods

### DIFF
--- a/moddingway/util.py
+++ b/moddingway/util.py
@@ -110,7 +110,11 @@ def chunk_message(message_content: str, max_chunk_length: int = 2000):
     to_index = 0
     while to_index < len(message_content):
         to_index = _split_chunks(message_content, from_index, max_chunk_length)
-        yield message_content[from_index:to_index]
+        line = message_content[from_index:to_index].strip()
+        if len(line) == 0:
+            from_index = to_index
+            continue 
+        yield line
         from_index = to_index
 
 

--- a/moddingway/util.py
+++ b/moddingway/util.py
@@ -113,7 +113,7 @@ def chunk_message(message_content: str, max_chunk_length: int = 2000):
         line = message_content[from_index:to_index].strip()
         if len(line) == 0:
             from_index = to_index
-            continue 
+            continue
         yield line
         from_index = to_index
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from typing import List
+
+import pytest
+
+from moddingway import util
+
+single_line_case = ("short message", 100, ["short message"])
+medium_len_case = (
+    "medium length message that gets broken in half",
+    35,
+    ["medium length message that gets", "broken in half"],
+)
+exact_length_case = ("first secon third", 5, ["first", "secon", "third"])
+
+
+@pytest.mark.parametrize(
+    "input,max_chunk_length,output_array",
+    [
+        single_line_case,
+        medium_len_case,
+        exact_length_case,
+    ],
+)
+def test_chunk_message(input: str, max_chunk_length: int, output_array: List[str]):
+    res = []
+
+    for line in util.chunk_message(input, max_chunk_length):
+        res.append(line)
+
+    assert res == output_array
+
+
+@pytest.mark.parametrize(
+    "input,expect",
+    [
+        (None, None),
+        ("1h", None),
+        ("100hour", None),
+        ("15sec", timedelta(seconds=15)),
+        ("55min", timedelta(minutes=55)),
+        ("1hour", timedelta(hours=1)),
+        ("3day", timedelta(days=3)),
+    ],
+)
+def test_calculate_time_delta(input, expect):
+    input = "1hour"
+    expect = timedelta(hours=1)
+
+    res = util.calculate_time_delta(input)
+
+    if expect is None:
+        assert res is None
+    else:
+        assert res == expect


### PR DESCRIPTION
Add a few simple tests for utils method. Fixed a bug with the message split method when a break happened exactly on a word, and trimmed the output

Ticket: NA