### PR TITLE
moderation commands now checks if target has the mod role

### DIFF
--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -89,7 +89,7 @@ def create_exile_commands(bot: Bot) -> None:
     )
     async def roulette(interaction: discord.Interaction):
         """Test your luck, fail and be exiled..."""
-        safety_options = [False]
+        safety_options = [True, True, True, True, True, False]
         exile_duration_options = [1, 6, 12, 18, 24]
         safety_choice = choice(safety_options)
         duration_choice = choice(exile_duration_options)

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -56,7 +56,7 @@ def create_exile_commands(bot: Bot) -> None:
                 ephemeral=True,
             )
             return
-        if user_has_role(interaction.user, Role.MOD):
+        if user_has_role(user, Role.MOD):
             logger.warning(
                 f"{interaction.user.id} used the exile command on {user.id}, it failed because targeted user is a mod."
             )

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -56,9 +56,12 @@ def create_exile_commands(bot: Bot) -> None:
                 ephemeral=True,
             )
             return
-        if user.top_role >= interaction.user.top_role:
+        if user_has_role(interaction.user, Role.MOD):
+            logger.warning(
+                f"{interaction.user.id} used the exile command on {user.id}, it failed because targeted user is a mod."
+            )
             await interaction.response.send_message(
-                f"Unable to exile {user.mention}: You cannot exile a user with an equal or higher role than yourself.",
+                f"Unable to exile {user.mention}: You cannot exile a mod.",
                 ephemeral=True,
             )
             return
@@ -86,7 +89,7 @@ def create_exile_commands(bot: Bot) -> None:
     )
     async def roulette(interaction: discord.Interaction):
         """Test your luck, fail and be exiled..."""
-        safety_options = [True, True, True, True, True, False]
+        safety_options = [False]
         exile_duration_options = [1, 6, 12, 18, 24]
         safety_choice = choice(safety_options)
         duration_choice = choice(exile_duration_options)

--- a/src/commands/exile_commands.py
+++ b/src/commands/exile_commands.py
@@ -86,7 +86,7 @@ def create_exile_commands(bot: Bot) -> None:
     )
     async def roulette(interaction: discord.Interaction):
         """Test your luck, fail and be exiled..."""
-        safety_options = [False]
+        safety_options = [True, True, True, True, True, False]
         exile_duration_options = [1, 6, 12, 18, 24]
         safety_choice = choice(safety_options)
         duration_choice = choice(exile_duration_options)

--- a/src/commands/strikes_command.py
+++ b/src/commands/strikes_command.py
@@ -1,9 +1,13 @@
 import discord
 from discord.ext.commands import Bot
-from util import is_user_moderator
+from util import is_user_moderator, user_has_role
 from enums import StrikeSeverity
 from .helper import create_logging_embed, create_response_context
 from services import strike_service
+from enums import Role
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def create_strikes_commands(bot: Bot) -> None:
@@ -16,6 +20,15 @@ def create_strikes_commands(bot: Bot) -> None:
         severity: StrikeSeverity,
         reason: str,
     ):
+        if user_has_role(user, Role.MOD):
+            logger.warning(
+                f"{interaction.user.id} used the add strike command on {user.id}, it failed because targeted user is a mod."
+            )
+            await interaction.response.send_message(
+                f"Unable to add strike to {user.mention}: You cannot add strike to a mod.",
+                ephemeral=True,
+            )
+            return
         """Add a strike to the user"""
         async with create_response_context(interaction) as response_message:
             async with create_logging_embed(

--- a/src/commands/strikes_command.py
+++ b/src/commands/strikes_command.py
@@ -22,7 +22,7 @@ def create_strikes_commands(bot: Bot) -> None:
                 interaction, user=user, reason=reason, severity=severity.name
             ) as logging_embed:
                 await strike_service.add_strike(
-                    logging_embed, user, severity, reason, interaction.user, interaction
+                    logging_embed, user, severity, reason, interaction.user
                 )
 
                 response_message.set_string(

--- a/src/services/exile_service.py
+++ b/src/services/exile_service.py
@@ -23,19 +23,9 @@ async def exile_user(
     user: discord.Member,
     duration: datetime.timedelta,
     reason: str,
-    interaction: discord.Interaction,
 ) -> Optional[str]:
     if not user_has_role(user, Role.VERIFIED):
         error_message = "User is not currently verified, no action will be taken"
-        log_info_and_add_field(
-            logging_embed,
-            logger,
-            "Error",
-            error_message,
-        )
-        return error_message
-    if user.top_role >= interaction.user.top_role:
-        error_message = f"Unable to exile {user.mention}: You cannot exile a user with an equal or higher role than yourself."
         log_info_and_add_field(
             logging_embed,
             logger,

--- a/src/services/strike_service.py
+++ b/src/services/strike_service.py
@@ -22,7 +22,6 @@ async def add_strike(
     severity: StrikeSeverity,
     reason: str,
     author: discord.Member,
-    interaction: discord.Interaction,
 ):
     # find user in DB
     db_user = users_database.get_user(user.id)
@@ -61,9 +60,7 @@ async def add_strike(
         f"<@{user.id}> was given a strike, bringing them to {db_user.get_strike_points()} points",
     )
 
-    punishment = await _apply_punishment(
-        logging_embed, user, db_user, previous_points, interaction
-    )
+    punishment = await _apply_punishment(logging_embed, user, db_user, previous_points)
     logging_embed.add_field(name="Punishment", value=punishment)
 
     # message user
@@ -129,7 +126,6 @@ async def _apply_punishment(
     user: discord.Member,
     db_user: User,
     previous_points: int,
-    interaction: discord.Interaction,
 ) -> str:
     total_points = db_user.get_strike_points()
 
@@ -161,10 +157,6 @@ async def _apply_punishment(
     else:
         punishment = f"{punishment_days} day exile"
         await exile_service.exile_user(
-            logging_embed,
-            user,
-            timedelta(days=punishment_days),
-            exile_reason,
-            interaction,
+            logging_embed, user, timedelta(days=punishment_days), exile_reason
         )
     return punishment


### PR DESCRIPTION
Ticket:MOD-90
ban command checks if target is a mod outside of context manager
exile command now checks if target is a mod instead of comparing top roles
when a mods roulette command goes through it mimicks a users version but doesnt do anything in the backend
removed interaction param from exile_user function as its not needed anymore 
add strike command now checks if target user has mod role
