### PR TITLE
Allow view strikes on non-members

### DIFF
--- a/moddingway/commands/exile_commands.py
+++ b/moddingway/commands/exile_commands.py
@@ -137,9 +137,7 @@ def create_exile_commands(bot: Bot) -> None:
     @bot.tree.command()
     @discord.app_commands.check(is_user_moderator)
     @discord.app_commands.describe(user="User whose logged exile are being viewed")
-    async def view_logged_exiles(
-        interaction: discord.Interaction, user: discord.Member
-    ):
+    async def view_logged_exiles(interaction: discord.Interaction, user: discord.User):
         """View logged exiles of a user."""
 
         async with create_response_context(interaction) as response_message:

--- a/moddingway/commands/note_commands.py
+++ b/moddingway/commands/note_commands.py
@@ -62,7 +62,7 @@ def create_note_commands(bot: Bot) -> None:
     @bot.tree.command()
     @discord.app_commands.check(is_user_moderator)
     @discord.app_commands.describe(user="User whose notes you are viewing")
-    async def view_notes(interaction: discord.Interaction, user: discord.Member):
+    async def view_notes(interaction: discord.Interaction, user: discord.User):
         """View the notes of the user"""
         async with create_response_context(interaction) as response_message:
             note_details = await note_service.get_user_notes(user)

--- a/moddingway/commands/strikes_command.py
+++ b/moddingway/commands/strikes_command.py
@@ -47,7 +47,7 @@ def create_strikes_commands(bot: Bot) -> None:
     @bot.tree.command()
     @discord.app_commands.check(is_user_moderator)
     @discord.app_commands.describe(user="User whose strikes you are viewing")
-    async def view_strikes(interaction: discord.Interaction, user: discord.Member):
+    async def view_strikes(interaction: discord.Interaction, user: discord.User):
         """View the strikes of the user"""
         async with create_response_context(interaction) as response_message:
             strike_details = await strike_service.get_user_strikes(user)

--- a/moddingway/services/note_service.py
+++ b/moddingway/services/note_service.py
@@ -57,7 +57,7 @@ async def get_note_by_id(
 
 
 async def get_user_notes(
-    user: discord.Member,
+    user: discord.User,
 ) -> str:
     db_user = users_database.get_user(user.id)
     if db_user is None:

--- a/moddingway/services/strike_service.py
+++ b/moddingway/services/strike_service.py
@@ -79,7 +79,7 @@ async def add_strike(
 
 
 async def get_user_strikes(
-    user: discord.Member,
+    user: discord.User,
 ) -> str:
     db_user = users_database.get_user(user.id)
     if db_user is None:


### PR DESCRIPTION
Ticket: MOD-139
This allows moderators to use `/view_strikes` on any user not in the server with their discord id.