### PR TITLE
Initial fastAPI setup with example endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,7 @@ database-clean:
 	docker exec postgres_db psql -f scripts/postgres/create_tables.sql -U moddingwayLocalDB moddingway
 	docker exec postgres_db psql -f scripts/postgres/seed_data.sql -U moddingwayLocalDB moddingway
 
+api:
+	python -m fastapi dev moddingway_api/main.py
+
 .PHONY: format stop install clean python-build python-run database-run

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,7 @@ database-clean:
 api:
 	uvicorn moddingway_api.main:app --port 8000
 
+api-reload:
+	uvicorn moddingway_api.main:app --port 8000 --reload
+
 .PHONY: format stop install clean python-build python-run database-run

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ database-clean:
 	docker exec postgres_db psql -f scripts/postgres/seed_data.sql -U moddingwayLocalDB moddingway
 
 api:
-	python -m fastapi dev moddingway_api/main.py
+	uvicorn moddingway_api.main:app --port 8000
 
 .PHONY: format stop install clean python-build python-run database-run

--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ By default, when you run the application either via python or docker, records in
 
 # API
 
-To get started with moddingway API development, install the necessary packages using `pip install -r requirements-api.txt`. From there, you can start the server by running `make api`. You can then view the swaggerdocs page hosted on `localhost:8000/docs` to view all current endpoints
+To get started with moddingway API development, install the necessary packages using `pip install -r requirements-api.txt`. From there, you can start the server by running `make api`. You can then view the swaggerdocs page hosted on `localhost:8000/docs` to view all current endpoints.
+
+Alternatively, if you want to have local changes reflected in realtime with your development API, you can run `make api-reload`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ By default, when you run the application either via python or docker, records in
 
 # API
 
-To get started with moddingway API development, install the necessary packages using `pip install -r requirements-api.txt`. From there, you can start the server by running `make api`. You can then view the swaggerdocs page hosted on `localhost:8000/docs` to view all current endpoints.
+To get started with moddingway API development, install the necessary packages using `pip install -r requirements.txt`. From there, you can start the server by running `make api`. You can then view the swaggerdocs page hosted on `localhost:8000/docs` to view all current endpoints.
 
 Alternatively, if you want to have local changes reflected in realtime with your development API, you can run `make api-reload`

--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ If you want to run the app in a container, you run the application via `make pyt
 
 ### Reseeding the Database
 By default, when you run the application either via python or docker, records in the database will persist. If you want to reset the database, you can do so by running `make database-clean` while the postgres container is running on your machine. If the database container is not found by the command, you can first start it by running `make database-run`
+
+# API
+
+To get started with moddingway API development, install the necessary packages using `pip install -r requirements-api.txt`. From there, you can start the server by running `make api`. You can then view the swaggerdocs page hosted on `localhost:8000/docs` to view all current endpoints

--- a/moddingway_api/main.py
+++ b/moddingway_api/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}

--- a/moddingway_api/main.py
+++ b/moddingway_api/main.py
@@ -1,8 +1,7 @@
 from fastapi import FastAPI
 
-app = FastAPI()
+from moddingway_api.routes import user_router
 
+app = FastAPI(title="Moddingway API")
 
-@app.get("/")
-async def root():
-    return {"message": "Hello World"}
+app.include_router(user_router, tags=["user"])

--- a/moddingway_api/routes/__init__.py
+++ b/moddingway_api/routes/__init__.py
@@ -1,0 +1,3 @@
+from moddingway_api.routes.user_routes import router as user_router
+
+__all__ = ["user_router"]

--- a/moddingway_api/routes/user_routes.py
+++ b/moddingway_api/routes/user_routes.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from fastapi import APIRouter
+
+from moddingway_api.schemas.user_schema import User
+
+router = APIRouter(prefix="/users")
+
+
+@router.get("/{user_id}")
+async def get_user_by_id(user_id: int) -> Optional[User]:
+    # This code is meant to demonstrate a get response
+    # feel free to modify it for actual purposes as necessary
+    return User(userID=str(user_id), isMod=False, strikePoints=1)

--- a/moddingway_api/schemas/user_schema.py
+++ b/moddingway_api/schemas/user_schema.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    # This class is meant to demonstrate a response model
+    # feel free to modify it for actual purposes as necessary
+    userID: str
+    isMod: bool
+    strikePoints: int

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,2 +1,0 @@
-fastapi[standard]==0.115.11
-pydantic

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,1 @@
+fastapi[standard]==0.115.11

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,1 +1,2 @@
 fastapi[standard]==0.115.11
+pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord
 pydantic
 psycopg2
 black
+fastapi[standard]==0.115.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ discord
 pydantic
 psycopg2
 black
-pydantic


### PR DESCRIPTION
Create initial fastAPI boilerplate with an example endpoint

ticket: MOD-66