### PR TITLE
Auto-unexile should work, Worker should clean up inactive forums

### DIFF
--- a/moddingway/util.py
+++ b/moddingway/util.py
@@ -200,12 +200,12 @@ def timestamp_to_epoch(timestamp: Optional[datetime]) -> Optional[int]:
 
 # TODO: MOD-166 add this check every time we are using the logging_channel_id
 # Try to get the logging channel for event logging
-def get_log_channel(guild):
+def get_log_channel(self):
     """
     Get the logging channel and handle errors if it doesn't exist.
     Returns the channel or None if not found.
     """
-    log_channel = guild.get_channel(settings.logging_channel_id)
+    log_channel = self.get_channel(settings.logging_channel_id)
 
     if log_channel is None:
         logger = logging.getLogger(__name__)

--- a/moddingway/workers/forum_automod.py
+++ b/moddingway/workers/forum_automod.py
@@ -37,7 +37,7 @@ async def autodelete_threads(self):
                 logger.error("Forum channel not found.")
                 continue
 
-            for thread in channel.archived_threads(limit=None):
+            async for thread in channel.archived_threads(limit=None):
                 num_removed, num_errors = await automod_thread(
                     thread,
                     duration,
@@ -73,7 +73,7 @@ async def autodelete_threads(self):
         except Exception as e:
             logger.error(e, exc_info=e)
             async with create_interaction_embed_context(
-                get_log_channel(self.guild),
+                get_log_channel(self),
                 user=self.user,
                 timestamp=datetime.now(timezone.utc),
                 description=f"Automod task failed to process channel <#{channel_id}>: {e}",

--- a/moddingway/workers/helper.py
+++ b/moddingway/workers/helper.py
@@ -36,7 +36,7 @@ def create_autounexile_embed(
 
 def create_automod_embed(self, channel_id, num_removed, num_error, timestamp: datetime):
     return create_interaction_embed_context(
-        get_log_channel(self.guild),
+        get_log_channel(self),
         user=self.user,
         timestamp=timestamp,
         description=f"Successfully removed {num_removed} inactive thread(s) from <#{channel_id}>.\n{num_error} inactive thread(s) failed to be removed.",

--- a/moddingway/workers/helper.py
+++ b/moddingway/workers/helper.py
@@ -26,12 +26,14 @@ def create_autounexile_embed(
 ):
 
     return create_interaction_embed_context(
-        get_log_channel(self.guild),
+        get_log_channel(self),
         user=user,
         timestamp=end_timestamp,
         description=f"<@{discord_id}>'s exile has timed out",
         footer=f"Exile ID: {exile_id}",
     )
+
+
 
 
 def create_automod_embed(self, channel_id, num_removed, num_error, timestamp: datetime):

--- a/moddingway/workers/helper.py
+++ b/moddingway/workers/helper.py
@@ -34,8 +34,6 @@ def create_autounexile_embed(
     )
 
 
-
-
 def create_automod_embed(self, channel_id, num_removed, num_error, timestamp: datetime):
     return create_interaction_embed_context(
         get_log_channel(self.guild),


### PR DESCRIPTION
[Refactored get_log_channel to use self instead of guild, updated calls](https://github.com/naurffxiv/moddingway/commit/04062ac86a72f3861484efb249e7a23641195e4d)

Refactored get_log_channel function to reference self instead of guild to resolve ModdingwayBot guild attribute reference exception. Updated usages in helper.py. Resolves Issue https://github.com/naurffxiv/moddingway/issues/334.