### PR TITLE
Reverted async definition of get_log_channel

### DIFF
--- a/moddingway/events/member_events.py
+++ b/moddingway/events/member_events.py
@@ -33,7 +33,7 @@ def register_events(bot: Bot):
 
         logger.info(f"Member joined: {member.display_name} ({member.id})")
 
-        log_channel = await get_log_channel(member.guild)
+        log_channel = get_log_channel(member.guild)
         if log_channel is None:
             return
 

--- a/moddingway/util.py
+++ b/moddingway/util.py
@@ -200,7 +200,7 @@ def timestamp_to_epoch(timestamp: Optional[datetime]) -> Optional[int]:
 
 # TODO: MOD-166 add this check every time we are using the logging_channel_id
 # Try to get the logging channel for event logging
-async def get_log_channel(self):
+def get_log_channel(self):
     """
     Get the logging channel and handle errors if it doesn't exist.
     Returns the channel or None if not found.


### PR DESCRIPTION
Reverted #353, as function is only accessing cached data.

Fixes broken manual automod command and on member join events.