### PR TITLE
Improve environment variable handling in settings

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -9,3 +9,7 @@ MOD_LOGGING_CHANNEL_ID ="<YOUR_MODDING_LOG_CHANNEL_HERE>"
 # Optional
 # INACTIVE_FORUM_CHANNEL_ID="<IGNORED_CHANNEL_ID>" # This channel watched by automod to archive threads
 # INACTIVE_FORUM_DURATION=30 # This is how often automod runs
+# NOTIFY_CHANNEL_ID = <NOTIFY_CHANNEL_ID> 
+# PTC_EVENT_FORUM_ID = "<PTC_EVENT_FORUM_ID>" # Set for PTC event
+# PTC_EVENT_FORUM_DURATION = "<PTC_EVENT_FORUM_DURATION(DAYS)>"  # Set for PTC event
+# EVENT_BOT_ID = "<RAID_HELPER_BOT_ID>" # Set for PTC event


### PR DESCRIPTION
Fixes #385
Updated settings.py to use default values and type conversion for environment variables. Added new optional environment variables for PTC event configuration in .env_example. All optional env values should be actually optional now.