### PR TITLE
Fix var naming error

### DIFF
--- a/moddingway/util.py
+++ b/moddingway/util.py
@@ -142,7 +142,7 @@ async def send_dm(
                 code
             )  # Check if Error Code is present in constants.py
             if error_template_msg:
-                formatted = error_template_msggit.format(
+                formatted = error_template_msg.format(
                     user=getattr(member, "id", member), context=context
                 )
                 log_info_and_add_field(logging_embed, logger, "DM Status", formatted)


### PR DESCRIPTION
fixes an issue where "git" was accidentally appended after a variable name