### PR TITLE
refactor: remove unnecessary logging from events on prod.

### DIFF
--- a/moddingway/events/member_events.py
+++ b/moddingway/events/member_events.py
@@ -32,7 +32,7 @@ def register_events(bot: Bot):
             member, Role.NON_VERIFIED
         )
 
-        logger.info(f"Member joined: {member.display_name} ({member.id})")
+        logger.debug(f"Member joined: {member.display_name} ({member.id})")
 
         log_channel = get_log_channel(member.guild)
         if log_channel is None:

--- a/moddingway/util.py
+++ b/moddingway/util.py
@@ -274,7 +274,7 @@ async def find_and_assign_role(
         # Assign the role to the member
         await member.add_roles(role)
         success_msg = f"Successfully assigned <@&{role.id}> role"
-        logger.info(success_msg)
+        logger.debug(success_msg)
         return True, success_msg, role
     except discord.Forbidden:
         error_msg = (


### PR DESCRIPTION
Closes #304.

This PR changes the log level of some logging calls in the events module from `info` to `debug`. This means we should only see those calls when running moddingway locally as on prod. we should be only seeing messages with a log level of `info` or higher.