### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 30
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: "pip"
+    directories:
+      - "/**"
+    open-pull-requests-limit: 30
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-discord
-pydantic
-psycopg2
-black
+discord==2.3.2
+pydantic==2.12.3
+psycopg2==2.9.11
+black==25.9.0
 fastapi[standard]==0.115.11


### PR DESCRIPTION
## Description

Adds the required dependabot config and pins all pip packages to specific versions so that dependabot can update them.

Fixes #408 