### PR TITLE
Updated API and DB to restrict ban appeal reason character count.

### DIFF
--- a/moddingway_api/routes/banforms_routes.py
+++ b/moddingway_api/routes/banforms_routes.py
@@ -68,6 +68,11 @@ async def submit_form(request: FormRequest):
             submission_timestamp=datetime.now(timezone.utc),
         )
 
+        if len(form.reason) > 1024:
+            return {
+                "detail": "Appeal reason max length is 1024 characters. Please shorten the appeal reason."
+            }
+
         result = banforms_database.add_form(form)
 
         if result:

--- a/postgres/create_tables.sql
+++ b/postgres/create_tables.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS roles (
 CREATE TABLE IF NOT EXISTS forms (
 	formID INT GENERATED ALWAYS AS IDENTITY,
 	userID INT NOT null,
-	reason TEXT,
+	reason VARCHAR(1024),
 	approvalNotes TEXT,
 	approval BOOL,
 	approvedByUserID INT,


### PR DESCRIPTION
Updated DB reason field in forms table to varchar 1024 datatype. 
Updated submit form function in banforms route to check if reason text exceeds 1024 characters. 
Resolves backend portion of Issue naurffxiv/naur#21.