### PR TITLE
fix: thread automod user id typo

### DIFF
--- a/moddingway/workers/helper.py
+++ b/moddingway/workers/helper.py
@@ -64,7 +64,7 @@ async def automod_thread(
         # skip the for loop if the thread is pinned
         return num_removed, num_errors
 
-    if user_id is not None and thread.owner.id != user_id:
+    if user_id is not None and thread.owner_id != user_id:
         return num_removed, num_errors
     # check if starter message was deleted
     starter_message = None


### PR DESCRIPTION
## Description

Fixes a typo where `thread.user_id` is set as `thread.user.id`

Fixes #419